### PR TITLE
deps: add npm to installation 

### DIFF
--- a/docs/build-dapps/requirements.md
+++ b/docs/build-dapps/requirements.md
@@ -84,7 +84,7 @@ And then test them:
 
 ```bash
 node –-version
-npm –-version
+npm version
 ```
 
 ## Yarn

--- a/docs/build-dapps/requirements.md
+++ b/docs/build-dapps/requirements.md
@@ -77,7 +77,7 @@ To install Node.js, follow [the official instructions](https://nodejs.org/en/dow
 
 ```bash
 curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-sudo apt-get install -y nodejs
+sudo apt-get install -y nodejs && apt install npm
 ```
 
 And then test them:


### PR DESCRIPTION
Ran into an issue when installing dependencies:

```bash
root@jcs-cartesi:~# node –-version
npm –-version
node:internal/modules/cjs/loader:959
  throw err;
  ^

Error: Cannot find module '/root/–-version'
    at Module._resolveFilename (node:internal/modules/cjs/loader:956:15)
    at Module._load (node:internal/modules/cjs/loader:804:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v18.7.0
Command 'npm' not found, but can be installed with:
apt install npm
```