### PR TITLE
URL Redirects for moved / removed pages

### DIFF
--- a/redirects.txt
+++ b/redirects.txt
@@ -1,0 +1,8 @@
+[
+    {
+        "source": "/build-dapps/",
+        "target": "/cartesi-rollups/build-dapps/",
+        "status": "301",
+        "condition": null
+    }
+]


### PR DESCRIPTION
To avoid broken links, make sure to update the `redirects.txt` file each time page is moved to a different location/url.