### PR TITLE
Adds Chainstack to faucet mentions + provider mentions

### DIFF
--- a/cartesi-rollups/api/json-rpc/basics.md
+++ b/cartesi-rollups/api/json-rpc/basics.md
@@ -26,7 +26,7 @@ There are two ways in which clients can interact with Ethereum-compatible nodes 
 
 Ethereum testnets are testing environments or networks that are designed to test the features and capabilities of the Ethereum blockchain without using real ETH and incurring any actual cost. There are several testnets available that simulate the Ethereum Mainnet. [Goerli](https://goerli.net/) is one of such testnets.
 
-A _faucet_ is a service that provides users with free testnet Ether tokens (GTH in the case of Goerli). These tokens can then be used to test and develop DApps on the testnet. There are several faucets available for Goerli. You may try [https://goerlifaucet.com/](https://goerlifaucet.com/).
+A _faucet_ is a service that provides users with free testnet Ether tokens (GTH in the case of Goerli). These tokens can then be used to test and develop DApps on the testnet. There are several faucets available for Goerli. You may try [https://goerlifaucet.com/](https://goerlifaucet.com/) or [https://faucet.chainstack.com/goerli-faucet](https://faucet.chainstack.com/goerli-faucet).
 
 #### Mainnet
 

--- a/cartesi-rollups/build-dapps/run-dapp.md
+++ b/cartesi-rollups/build-dapps/run-dapp.md
@@ -168,8 +168,8 @@ yarn
 yarn build
 ```
 4. You can [follow this tutorial to create an Ethereum account using Metamask](https://support.metamask.io/hc/en-us/articles/360015489531). Make sure to save the Secret Backup Phrase (MNEMONIC user sequence of twelve words)
-5. Get testnet funds/tokens on Goerli to be able to submit transactions on that network. There are several faucets available, you may try [https://goerlifaucet.com/](https://goerlifaucet.com/) or [https://goerli-faucet.slock.it/](https://goerli-faucet.slock.it/)
-6. Create an [Alchemy account](https://docs.alchemy.com/docs/alchemy-quickstart-guide) to obtain an API key for reliable access to the Goerli network. Alternatively, you can use other options such as [Infura](https://infura.io/) or [Moralis](https://moralis.io/)
+5. Get testnet funds/tokens on Goerli to be able to submit transactions on that network. There are several faucets available, you may try [https://goerlifaucet.com/](https://goerlifaucet.com/), [https://goerli-faucet.slock.it/](https://goerli-faucet.slock.it/) or [https://faucet.chainstack.com/goerli-faucet](https://faucet.chainstack.com/goerli-faucet)
+6. Create an [Alchemy account](https://docs.alchemy.com/docs/alchemy-quickstart-guide) to obtain an API key for reliable access to the Goerli network. Alternatively, you can use other options such as [Infura](https://infura.io/) or [Chainstack](https://chainstack.com/)
 7. Configure your account on Goerli by running the commands below, which specify the network and MNEMONIC (Secret Backup Phrase) to use. The MNEMONIC is always specified as a string sequence of twelve words. In this example, use the MNEMONIC that you received when creating the Ethereum account using Metamask as described in step 4.
 ```shell
 export NETWORK=goerli


### PR DESCRIPTION
This is a small PR that includes Chainstack among 2 instances in which Goerli faucets are mentioned, as well as an additional instance of node providers being mentioned (Chainstack replaced Moralis in this PR, as Moralis no longer provides managed blockchain nodes)