### PR TITLE
Clarify that the DApp backend must be running

### DIFF
--- a/cartesi-rollups/build-dapps/create-dapp.md
+++ b/cartesi-rollups/build-dapps/create-dapp.md
@@ -180,9 +180,13 @@ The `quote` runs the command stored in FORTUNE_CMD using a shell, captures the o
 
 ## Create the Docker build for the new DApp
 
+The following command is executed to construct a Docker image for our DApp and ensure that the built image is directly loaded into the local Docker instance. This makes it immediately ready for deployment or testing:
+
 ```shell
 docker buildx bake --load
 ```
+
+The `docker buildx` is an extended toolset for Docker, which provides full support for the features of the Moby BuildKit builder toolkit. The `bake` command is part of this extension and simplifies the process of defining and running builds by using a declarative format in the form of a `docker-bake.hcl` or a `docker-compose.yml`. When the `--load` flag is added, it instructs BuildKit to build the Docker image and then immediately load it into the local Docker runtime environment.
 
 
 ## Build the frontend console

--- a/cartesi-rollups/build-dapps/run-dapp.md
+++ b/cartesi-rollups/build-dapps/run-dapp.md
@@ -112,6 +112,10 @@ Every Rollups DApp gets an address on the base layer when it's deployed. The fol
 
 ### Interacting locally with the DApp
 
+:::note
+Ensure that the DApp's backend is running before proceeding with the following steps.
+:::
+
 The following steps describe how to send an input to the Echo DApp instance that is running locally:
 
 1. Open a separate terminal window


### PR DESCRIPTION
Clarify that the DApp backend must be running before running the Run DApp tutorial