### PR TITLE
removed repetition from "dapp-host-mode" docs

### DIFF
--- a/cartesi-rollups/build-dapps/dapp-host-mode.md
+++ b/cartesi-rollups/build-dapps/dapp-host-mode.md
@@ -31,7 +31,7 @@ If you have PostgreSQL and Redis already installed on your system, you may encou
 ## Step 2: Run the application back-end
 
 The next step is to run the application back-end in your machine. Before proceeding, ensure that you have installed the dependencies and libraries required for your selected language. For example, if the code is written in Python, you will need to have `python3` installed.
-The next step is to run the application back-end in your machine. Before proceeding, ensure that you have installed the dependencies and libraries required for your selected language. For example, if the code is written in Python, you will need to have `python3` installed.
+
 
 If you are using the `echo-python` example, in order to start the back-end, run the following commands in a dedicated terminal:
 

--- a/cartesi-rollups/build-dapps/dapp-host-mode.md
+++ b/cartesi-rollups/build-dapps/dapp-host-mode.md
@@ -37,8 +37,8 @@ If you are using the `echo-python` example, in order to start the back-end, run 
 
 ```shell
 cd echo-python/
-python3 -m venv .env
-. .env/bin/activate
+python3 -m venv .venv
+. .venv/bin/activate
 pip install -r requirements.txt
 ROLLUP_HTTP_SERVER_URL="http://127.0.0.1:5004" python3 echo.py
 ```


### PR DESCRIPTION
The line below repeated. Got rid of one.

_The next step is to run the application back-end in your machine. Before proceeding, ensure that you have installed the dependencies and libraries required for your selected language. For example, if the code is written in Python, you will need to have `python3` installed._
