### PR TITLE
fix: sunodo-tabs preview bug

### DIFF
--- a/cartesi-rollups/api/inspect/inspect-state-http-api-for-cartesi-rollups.info.mdx
+++ b/cartesi-rollups/api/inspect/inspect-state-http-api-for-cartesi-rollups.info.mdx
@@ -12,15 +12,14 @@ import ApiLogo from "@theme/ApiLogo";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-<span className={"theme-doc-version-badge badge badge--secondary"}>
-  Version: 0.5.1
-</span>
+<span className={"theme-doc-version-badge badge badge--secondary"}>Version: 0.5.1</span>
 
 # Inspect-state HTTP API for Cartesi Rollups
 
+
+
 API that allows the dApp frontend to make inspect-state requests to the dApp backend.
 
-<div style={{ marginBottom: "var(--ifm-paragraph-margin-bottom)" }}>
-  <h3 style={{ marginBottom: "0.25rem" }}>License</h3>
-  <a href={"https://www.apache.org/licenses/LICENSE-2.0.html"}>Apache-2.0</a>
-</div>
+
+<div style={{"marginBottom":"var(--ifm-paragraph-margin-bottom)"}}><h3 style={{"marginBottom":"0.25rem"}}>License</h3><a href={"https://www.apache.org/licenses/LICENSE-2.0.html"}>Apache-2.0</a></div>
+      

--- a/cartesi-rollups/api/inspect/inspect.api.mdx
+++ b/cartesi-rollups/api/inspect/inspect.api.mdx
@@ -26,12 +26,14 @@ import ApiTabs from "@theme/ApiTabs";
 import MimeTabs from "@theme/MimeTabs";
 import ParamsItem from "@theme/ParamsItem";
 import ResponseSamples from "@theme/ResponseSamples";
-import SchemaItem from "@theme/SchemaItem";
+import SchemaItem from "@theme/SchemaItem"
 import SchemaTabs from "@theme/SchemaTabs";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import TabItem from "@theme/TabItem";
 
 ## Inspect dApp state REST API
+
+
 
 This method sends an inspect-state request to the dApp backend passing the payload string in the URL.
 The payload string should be URL-encoded; the inspect server will decode the string to UTF-8.
@@ -46,6 +48,7 @@ When running on machine mode, the whole Cartesi Machine is rolled back after pro
 On host mode, it is advised against changing the dApp backend state when processing an inspect-state request.
 Notice that this method is synchronous, so it is not advised to perform resource-intensive operations.
 
+
 <details style={{"marginBottom":"1rem"}} data-collapsed={false} open={true}><summary style={{}}><strong>Path Parameters</strong></summary><div><ul><ParamsItem className={"paramsItem"} param={{"in":"path","name":"payload","required":true,"schema":{"type":"string"}}}></ParamsItem></ul></div></details><div><ApiTabs><TabItem label={"200"} value={"200"}><div>
 
 Inspect state response.
@@ -59,3 +62,4 @@ Error response.
 Detailed error message.
 
 </div></div></li></ul></details></TabItem></SchemaTabs></TabItem></MimeTabs></div></TabItem></ApiTabs></div>
+      

--- a/cartesi-rollups/api/rollup/add-notice.api.mdx
+++ b/cartesi-rollups/api/rollup/add-notice.api.mdx
@@ -20,12 +20,14 @@ import ApiTabs from "@theme/ApiTabs";
 import MimeTabs from "@theme/MimeTabs";
 import ParamsItem from "@theme/ParamsItem";
 import ResponseSamples from "@theme/ResponseSamples";
-import SchemaItem from "@theme/SchemaItem";
+import SchemaItem from "@theme/SchemaItem"
 import SchemaTabs from "@theme/SchemaTabs";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import TabItem from "@theme/TabItem";
 
 ## Add a new notice
+
+
 
 The dApp backend can call this method to add a new notice when processing the advance-state request.
 A notice describes any changes to the internal state of the dApp that may be relevant to the blockchain.
@@ -33,6 +35,7 @@ Between calls to the finish method, the notice method can be called up to 32k ti
 
 The returned value is the index of the notice for the current advance request.
 In other words, the index counting restarts at every request.
+
 
 <MimeTabs><TabItem label={"application/json"} value={"application/json-schema"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Request Body</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><SchemaItem collapsible={false} name={"payload"} required={false} schemaDescription={"The payload is in the Ethereum hex binary format.\nThe first two characters are '0x' followed by pairs of hexadecimal numbers that correspond to one byte.\nFor instance, '0xdeadbeef' corresponds to a payload with length 4 and bytes 222, 173, 190, 175.\nAn empty payload is represented by the string '0x'.\n"} schemaName={"string"} qualifierMessage={undefined} defaultValue={undefined}></SchemaItem></ul></details></TabItem></MimeTabs><div><ApiTabs><TabItem label={"200"} value={"200"}><div>
 
@@ -47,4 +50,4 @@ Error response.
 Detailed error message.
 
 </div></div></li></ul></details></TabItem></SchemaTabs></TabItem></MimeTabs></div></TabItem></ApiTabs></div>
-
+      

--- a/cartesi-rollups/api/rollup/add-report.api.mdx
+++ b/cartesi-rollups/api/rollup/add-report.api.mdx
@@ -17,16 +17,19 @@ import ApiTabs from "@theme/ApiTabs";
 import MimeTabs from "@theme/MimeTabs";
 import ParamsItem from "@theme/ParamsItem";
 import ResponseSamples from "@theme/ResponseSamples";
-import SchemaItem from "@theme/SchemaItem";
+import SchemaItem from "@theme/SchemaItem"
 import SchemaTabs from "@theme/SchemaTabs";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import TabItem from "@theme/TabItem";
 
 ## Add a new report
 
+
+
 The dApp can call this method to add a new report for the given rollup request.
 A report can be a diagnostic or a log; reports are not discarded when a request is rejected.
 Between calls to the finish method, the report method can be called any number of times.
+
 
 <MimeTabs><TabItem label={"application/json"} value={"application/json-schema"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Request Body</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><SchemaItem collapsible={false} name={"payload"} required={false} schemaDescription={"The payload is in the Ethereum hex binary format.\nThe first two characters are '0x' followed by pairs of hexadecimal numbers that correspond to one byte.\nFor instance, '0xdeadbeef' corresponds to a payload with length 4 and bytes 222, 173, 190, 175.\nAn empty payload is represented by the string '0x'.\n"} schemaName={"string"} qualifierMessage={undefined} defaultValue={undefined}></SchemaItem></ul></details></TabItem></MimeTabs><div><ApiTabs><TabItem label={"200"} value={"200"}><div>
 
@@ -41,4 +44,4 @@ Error response.
 Detailed error message.
 
 </div></div></li></ul></details></TabItem></SchemaTabs></TabItem></MimeTabs></div></TabItem></ApiTabs></div>
-
+      

--- a/cartesi-rollups/api/rollup/add-voucher.api.mdx
+++ b/cartesi-rollups/api/rollup/add-voucher.api.mdx
@@ -20,12 +20,14 @@ import ApiTabs from "@theme/ApiTabs";
 import MimeTabs from "@theme/MimeTabs";
 import ParamsItem from "@theme/ParamsItem";
 import ResponseSamples from "@theme/ResponseSamples";
-import SchemaItem from "@theme/SchemaItem";
+import SchemaItem from "@theme/SchemaItem"
 import SchemaTabs from "@theme/SchemaTabs";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import TabItem from "@theme/TabItem";
 
 ## Add a new voucher
+
+
 
 The dApp backend can call this method to add a new voucher when processing an advance-state request.
 Vouchers are collateral effects actionable in the blockchain.
@@ -33,6 +35,7 @@ Between calls to the finish method, the voucher method can be called up to 32k t
 
 The returned value is the index of the voucher for the current advance-state request.
 In other words, the index counting restarts at every request.
+
 
 <MimeTabs><TabItem label={"application/json"} value={"application/json-schema"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Request Body</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><SchemaItem collapsible={false} name={"destination"} required={false} schemaDescription={"20-byte address of the destination contract for which the payload will be sent."} schemaName={"string"} qualifierMessage={undefined} defaultValue={undefined}></SchemaItem><SchemaItem collapsible={false} name={"payload"} required={false} schemaDescription={"String in Ethereum hex binary format describing a method call to be executed by the destination contract.\nThe first two characters are '0x' followed by pairs of hexadecimal numbers that correspond to one byte.\nFor instance, '0xcdcd77c0' corresponds to a payload with length 4 and bytes 205, 205, 119, 192.\nTo describe the method call, the payload should consist of a function selector (method identifier) followed\nby its ABI-encoded arguments.\nref: https://docs.soliditylang.org/en/v0.8.19/abi-spec.html\n"} schemaName={"string"} qualifierMessage={undefined} defaultValue={undefined}></SchemaItem></ul></details></TabItem></MimeTabs><div><ApiTabs><TabItem label={"200"} value={"200"}><div>
 
@@ -47,4 +50,4 @@ Error response.
 Detailed error message.
 
 </div></div></li></ul></details></TabItem></SchemaTabs></TabItem></MimeTabs></div></TabItem></ApiTabs></div>
-
+      

--- a/cartesi-rollups/api/rollup/cartesi-rollup-http-api.info.mdx
+++ b/cartesi-rollups/api/rollup/cartesi-rollup-http-api.info.mdx
@@ -71,11 +71,11 @@ import ApiLogo from "@theme/ApiLogo";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-<span className={"theme-doc-version-badge badge badge--secondary"}>
-  Version: 0.5.1
-</span>
+<span className={"theme-doc-version-badge badge badge--secondary"}>Version: 0.5.1</span>
 
 # Cartesi Rollup HTTP API
+
+
 
 API that the Cartesi Rollup HTTP Server implements.
 
@@ -138,7 +138,6 @@ See [/exception](#api-Default-registerException).
 In host mode, the Cartesi Rollups infrastructure is not able to detect that the dApp exited.
 It is up to the dApp developer to re-launch the dApp.
 
-<div style={{ marginBottom: "var(--ifm-paragraph-margin-bottom)" }}>
-  <h3 style={{ marginBottom: "0.25rem" }}>License</h3>
-  <a href={"https://www.apache.org/licenses/LICENSE-2.0.html"}>Apache-2.0</a>
-</div>
+
+<div style={{"marginBottom":"var(--ifm-paragraph-margin-bottom)"}}><h3 style={{"marginBottom":"0.25rem"}}>License</h3><a href={"https://www.apache.org/licenses/LICENSE-2.0.html"}>Apache-2.0</a></div>
+      

--- a/cartesi-rollups/api/rollup/finish.api.mdx
+++ b/cartesi-rollups/api/rollup/finish.api.mdx
@@ -34,12 +34,14 @@ import ApiTabs from "@theme/ApiTabs";
 import MimeTabs from "@theme/MimeTabs";
 import ParamsItem from "@theme/ParamsItem";
 import ResponseSamples from "@theme/ResponseSamples";
-import SchemaItem from "@theme/SchemaItem";
+import SchemaItem from "@theme/SchemaItem"
 import SchemaTabs from "@theme/SchemaTabs";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import TabItem from "@theme/TabItem";
 
 ## Finish and get next request
+
+
 
 The dApp backend should call this method to start processing rollup requests.
 The Rollup HTTP Server returns the next rollup request in the response body.
@@ -62,6 +64,7 @@ When the dApp backend and the Rollup HTTP Server are running inside a Cartesi Ma
 When running in host mode, the Rollup HTTP Server returns the status code 202 after 10 seconds to avoid the connection timing out.
 When the Rollup HTTP Server returns 202, the dApp backend should retry the call to finish passing the same arguments as before.
 
+
 <MimeTabs><TabItem label={"application/json"} value={"application/json-schema"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Request Body</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><SchemaItem collapsible={false} name={"status"} required={false} schemaDescription={undefined} schemaName={"string"} qualifierMessage={"**Possible values:** [`accept`, `reject`]"} defaultValue={undefined}></SchemaItem></ul></details></TabItem></MimeTabs><div><ApiTabs><TabItem label={"200"} value={"200"}><div>
 
 Finish accepted and next rollup request returned.
@@ -79,3 +82,4 @@ Error response.
 Detailed error message.
 
 </div></div></li></ul></details></TabItem></SchemaTabs></TabItem></MimeTabs></div></TabItem></ApiTabs></div>
+      

--- a/cartesi-rollups/api/rollup/register-exception.api.mdx
+++ b/cartesi-rollups/api/rollup/register-exception.api.mdx
@@ -22,12 +22,14 @@ import ApiTabs from "@theme/ApiTabs";
 import MimeTabs from "@theme/MimeTabs";
 import ParamsItem from "@theme/ParamsItem";
 import ResponseSamples from "@theme/ResponseSamples";
-import SchemaItem from "@theme/SchemaItem";
+import SchemaItem from "@theme/SchemaItem"
 import SchemaTabs from "@theme/SchemaTabs";
 import DiscriminatorTabs from "@theme/DiscriminatorTabs";
 import TabItem from "@theme/TabItem";
 
 ## Register an exception
+
+
 
 The dApp should call this method when it cannot proceed with the request processing after an exception happens.
 This method should be the last method ever called by the dApp backend while processing a request.
@@ -37,6 +39,7 @@ No HTTP status code will be sent or received.
 
 When running in host mode, the Rollup HTTP Server returns the status code 200.
 In both cases, the input will be skipped with the reason EXCEPTION and the exception message will be forwarded.
+
 
 <MimeTabs><TabItem label={"application/json"} value={"application/json-schema"}><details style={{}} data-collapsed={false} open={true}><summary style={{"textAlign":"left"}}><strong>Request Body</strong></summary><div style={{"textAlign":"left","marginLeft":"1rem"}}></div><ul style={{"marginLeft":"1rem"}}><SchemaItem collapsible={false} name={"payload"} required={false} schemaDescription={"The payload is in the Ethereum hex binary format.\nThe first two characters are '0x' followed by pairs of hexadecimal numbers that correspond to one byte.\nFor instance, '0xdeadbeef' corresponds to a payload with length 4 and bytes 222, 173, 190, 175.\nAn empty payload is represented by the string '0x'.\n"} schemaName={"string"} qualifierMessage={undefined} defaultValue={undefined}></SchemaItem></ul></details></TabItem></MimeTabs><div><ApiTabs><TabItem label={"200"} value={"200"}><div>
 
@@ -51,4 +54,4 @@ Error response.
 Detailed error message.
 
 </div></div></li></ul></details></TabItem></SchemaTabs></TabItem></MimeTabs></div></TabItem></ApiTabs></div>
-
+      

--- a/cartesi-rollups/build-dapps/requirements.md
+++ b/cartesi-rollups/build-dapps/requirements.md
@@ -9,7 +9,7 @@ To start developing applications using Cartesi Rollups, first make sure that the
 :::note Section Goal
 
 - ensure you have all the necessary dependencies for building Cartesi dApps
-  :::
+:::
 
 ## Basic tools
 
@@ -67,6 +67,7 @@ After that, you can check if Docker is property installed by running:
 ```
 docker --version
 ```
+
 
 It is recommended that the installed Docker version be at least `20.10.14` in order to adequately build a development environment and execute [example dApps](https://github.com/cartesi/rollups-examples) made available by Cartesi.
 


### PR DESCRIPTION
## Brief
- Fixed a bug that caused installation tabs to show improperly.

## Activities
- I identified and addressed a display issue with the tabs on the [General Requirements page](https://docs.cartesi.io/cartesi-rollups/build-dapps/requirements/#sunodo) of our documentation. The root cause was traced to incorrect indentation within the markdown of the `requirements.md` file, specifically within the note section. This has been corrected to ensure proper rendering of the tabs when viewed in the documentation. Please review the changes to confirm that the tabbed content now displays as intended.

## Evidence

**Before Fix**
<img width="1242" alt="Screenshot 2023-12-13 at 8 03 05 AM" src="https://github.com/cartesi/docs/assets/65580797/70fd1ef9-f5c3-47d2-a3b0-4a3131c41fc2">

**After Fix**
<img width="1283" alt="Screenshot 2023-12-13 at 9 09 04 AM" src="https://github.com/cartesi/docs/assets/65580797/889b9faf-6423-4bd0-8dfb-f708dcc3df69">
