### PR TITLE
Fix: Footer Text Visibility in Light Mode + Note indentation error

### DIFF
--- a/cartesi-rollups/overview.md
+++ b/cartesi-rollups/overview.md
@@ -50,7 +50,7 @@ Non-interactive refers to the fact that the challengers can prove that a state u
 - Executes transaction computations off-chain. This way the computations are not carried out by the base layer. Instead, they are executed in a separate computation environment and the rollup protocol ensures transaction validity via either validity proofs or fraud proofs.
 - Capable of compressing data from several transactions into a bundle to decrease both transaction costs and size, increasing overall efficiency.
 - Allows blockchains to scale while keeping the security guarantees of its consensus mechanism.
-  :::
+:::
 
 ## Cartesi Rollups
 

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -17,7 +17,7 @@ function Footer() {
             </div>
             <FooterNav />
           </div>
-          <div className="flex items-center justify-between gap-4 text-xs text-background/50">
+          <div className="flex items-center justify-between gap-4 text-xs text-white">
             <p>© 2023 Cartesi Foundation Ltd. All rights reserved.</p>
             <p>
               The Cartesi Project is commissioned by the Cartesi Foundation.


### PR DESCRIPTION
## Brief and Activities
- As raised in [issue 148](https://github.com/cartesi/docs/issues/148), I fixed the text visibility in the order by assigning the class `text-white` 
- I fixed a note indentation error that caused some parts of the text to preview as "note"

## Evidences

### 1. Fix for Footer Text Visibility
<img width="2041" alt="Screenshot 2023-12-19 at 10 13 01 AM" src="https://github.com/cartesi/docs/assets/65580797/e39ca11d-3228-4b0f-8a83-04e47f387d51">

### 2. Indentation Fix
**Before**
<img width="1703" alt="before indentation fix" src="https://github.com/cartesi/docs/assets/65580797/1b89f0e9-32c5-4caa-a654-21ceb434c7f4">

**After**
<img width="1569" alt="Screenshot 2023-12-19 at 10 21 05 AM" src="https://github.com/cartesi/docs/assets/65580797/270e7ac4-8d13-44a9-a5e7-4a130c2a625d">
