### PR TITLE
update: link to supported networks

### DIFF
--- a/cartesi-rollups/build-dapps/deploying-dapps.md
+++ b/cartesi-rollups/build-dapps/deploying-dapps.md
@@ -14,7 +14,7 @@ In order to facilitate the instantiation of such nodes, Cartesi provides an infr
 
 As stated above, the first step in the deployment of a new Cartesi dApp to a blockchain requires creating a smart contract on that network that makes use of the Cartesi Rollups smart contracts. For convenience, Cartesi has already deployed the Rollups smart contracts to a number of networks, in order to make it easier for developers to create dApps on them.
 
-The table below shows the list of all [networks that are currently supported](https://github.com/cartesi/rollups-contracts/tree/main/onchain/rollups/deployments) in the latest Cartesi Rollups release:
+The table below shows the list of all [networks that are currently supported](https://github.com/cartesi/rollups-contracts/tree/main/deployments) in the latest Cartesi Rollups release:
 
 | Network Name    | Chain ID |
 | --------------- | -------- |


### PR DESCRIPTION
## Brief

- Update link to supported networks

## Activities

- Deployment network links were broken due to docs refactors in the rollup-contract repo. Fixed it with new links

## Evidence

https://github.com/cartesi/docs/assets/65580797/b355a9f1-5d91-4657-816f-4951ad9d523d

