### PR TITLE
update:enhancements to quickstart, tutorials, and troubleshooting docs

### DIFF
--- a/cartesi-rollups/core-concepts/optimistic-rollups.md
+++ b/cartesi-rollups/core-concepts/optimistic-rollups.md
@@ -70,7 +70,7 @@ Transactions and computations occur off-chain, leading to more intricate logic w
 Cartesi's architecture specializes in app-specific rollups(appchains). Each dApp has its dedicated rollup for off-chain computation, enhancing scalability and performance. 
 
 
-## Introduction Dave — an interactive fraud-proof system
+## Introducing Dave — an interactive fraud-proof system
 
 [Dave](https://github.com/cartesi/dave) is Cartesi's dispute resolution algorithm designed to address shortcomings in existing fraud-proof protocols. Traditional fraud-proof systems often face challenges such as delay attacks and vulnerability to Sybil attacks, where malicious nodes can disrupt operations by continuously challenging transactions or overwhelming honest validators.
 

--- a/cartesi-rollups/core-concepts/optimistic-rollups.md
+++ b/cartesi-rollups/core-concepts/optimistic-rollups.md
@@ -78,3 +78,4 @@ Dave introduces an approach where the resources required to defend against dispu
 
 With Dave, a single honest participant can effectively defend their claims on-chain, ensuring the integrity of transactions without relying on trust in validators. Based on the [Permissionless Refereed Tournaments algorithm](https://arxiv.org/abs/2212.12439), this protocol empowers anyone to validate rollups and uphold correct states on-chain, enhancing transaction security and reliability.
 
+In a way similar to how a consensus algorithm is crucial for achieving agreement on a single state of the blockchain among all nodes in a base layer chain, Dave plays a fundamental role in ensuring the integrity and trustworthiness of state transitions within Cartesi Rollups.

--- a/cartesi-rollups/development/creating-application.md
+++ b/cartesi-rollups/development/creating-application.md
@@ -12,7 +12,7 @@ sunodo create <dapp-name> --template <language>
 For example, create a Python project.
 
 ```
-sunodo create new-dapp --template python.
+sunodo create new-dapp --template python
 ```
 
 This command creates a `new-dapp` directory with essential files for your dApp development.

--- a/cartesi-rollups/development/installation.md
+++ b/cartesi-rollups/development/installation.md
@@ -38,6 +38,15 @@ apt install qemu-user-static
 
 :::
 
+
+## Install Node.js
+
+To download the latest version of Node.js, visit [nodejs.org/en/download](https://nodejs.org/en/download).
+
+After downloading, run the installer and follow the instructions to complete the installation.
+
+Verify the installation by running `node -v`, which will display the version of Node.js that was installed.
+
 ## Install Sunodo
 
 import Tabs from '@theme/Tabs';

--- a/cartesi-rollups/development/installation.md
+++ b/cartesi-rollups/development/installation.md
@@ -18,23 +18,26 @@ Docker Desktop is a must-have requirement that comes pre-configured with two nec
 
 Follow [the instructions here to install Docker Desktop](https://www.docker.com/products/docker-desktop/) for your operating system.
 
-:::troubleshoot
+:::troubleshoot troubleshooting common errors
 
+#### Error: Invalid image Architecture
 ```
 Error: Invalid image Architecture: Expected riscv64
 ```
 
-Check if your Docker supports the RISCV platform by running:
+#### Solution:
 
-```
-docker buildx ls
-```
+1. Check if your Docker supports the RISCV platform by running:
 
-If you do not see `linux/riscv64` in the platforms list, install `QEMU` by running:
+  ```
+  docker buildx ls
+  ```
 
-```
-apt install qemu-user-static
-```
+2. If you do not see `linux/riscv64` in the platforms list, install `QEMU` by running:
+
+  ```
+  apt install qemu-user-static
+  ```
 
 :::
 

--- a/cartesi-rollups/development/running-the-application.md
+++ b/cartesi-rollups/development/running-the-application.md
@@ -16,37 +16,53 @@ NoNodo is a light development tool that does not require Docker running and allo
 
 ## Production Mode
 
-Before running in this mode, you must successfully build a Cartesi machine snapshot with sunodo build.
+Here are the prerequisites to run the node in production mode:
 
-To start in production mode, the Docker Engine must be on. Run the following command:
+- Docker Engine must be active.
+- Cartesi machine snapshot successfully built with `sunodo build`.
+
+To start the node in production mode:
 
 ```
 sunodo run
 ```
 
-`sunodo run` will run a node with your backend compiled to RISC-V and packaged as a Cartesi machine.
+This command runs your backend compiled to RISC-V and packages it as a Cartesi machine.
 
-After successfully running a node, your application can receive inputs.
+:::troubleshoot troubleshooting common errors
 
-:::troubleshoot
-
+##### Error: Depth Too High
 ```
-Error: Depth Too High
-
 Attaching to 2bd74695-prompt-1, 2bd74695-validator-1
 2bd74695-validator-1  | Error: DepthTooHigh { depth: 2, latest: 1 }
 2bd74695-validator-1  | Error: DepthTooHigh { depth: 2, latest: 1 }
 ```
 
-This error happens when the node reads too many blocks behind the blockchain.
+This indicates that the node is reading blocks too far behind the current blockchain state.
 
-To fix this, create a `.sunodo.env.` and overwrite the set `TX_DEFAULT_CONFIRMATIONS` to 1, as in:
+##### Solution:
+
+Create or modify a `.sunodo.env` file in your project directory and set:
 
 ```
 TX_DEFAULT_CONFIRMATIONS=1
 ```
+This adjustment should align the node's block reading with the blockchain's current state.
 
 :::
+
+### Overview of Node Services
+
+The `sunodo run` command activates several services essential for node operation:
+
+- **Anvil Chain**: Runs a local blockchain available at `http://localhost:8545`.
+
+- **GraphQL Playground**: An interactive IDE at `http://localhost:8080/graphql` for exploring the GraphQL server.
+
+- **Blockchain Explorer**: Monitors node activity and manages transactions via `http://localhost:8080/explorer/`.
+
+- **Inspect**: A diagnostic tool accessible at `http://localhost:8080/inspect/` to inspect the node’s state.
+
 
 ## NoNodo (Testing & Development)
 

--- a/cartesi-rollups/development/running-the-application.md
+++ b/cartesi-rollups/development/running-the-application.md
@@ -31,7 +31,7 @@ This command runs your backend compiled to RISC-V and packages it as a Cartesi m
 
 :::troubleshoot troubleshooting common errors
 
-##### Error: Depth Too High
+#### Error: Depth Too High
 ```
 Attaching to 2bd74695-prompt-1, 2bd74695-validator-1
 2bd74695-validator-1  | Error: DepthTooHigh { depth: 2, latest: 1 }
@@ -40,7 +40,7 @@ Attaching to 2bd74695-prompt-1, 2bd74695-validator-1
 
 This indicates that the node is reading blocks too far behind the current blockchain state.
 
-##### Solution:
+#### Solution:
 
 Create or modify a `.sunodo.env` file in your project directory and set:
 

--- a/cartesi-rollups/quickstart.md
+++ b/cartesi-rollups/quickstart.md
@@ -24,6 +24,8 @@ If you use Windows, you must have [WSL2 installed and configured](https://learn.
 
 1. [Install Docker Desktop for your operating system](https://www.docker.com/products/docker-desktop/).
 
+1. [Download and install the latest version of Node.js](https://nodejs.org/en/download).
+
 2. Sunodo is an easy-to-use CLI tool to build and deploy your dApps. To install Sunodo, run:
 
    ```shell

--- a/cartesi-rollups/tutorials/calculator.md
+++ b/cartesi-rollups/tutorials/calculator.md
@@ -270,6 +270,21 @@ To send generic inputs to our application quickly, run the following:
 sunodo send generic
 ```
 
+Example: Send `1+2` as an input to the application.
+
+```shell
+> sunodo send generic
+? Chain Foundry
+? RPC URL http://127.0.0.1:8545
+? Wallet Mnemonic
+? Mnemonic test test test test test test test test test test test junk
+? Account 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 9999.970671818064986684 ETH
+? Application address 0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e
+? Input String encoding
+? Input (as string) 1+2
+✔ Input sent: 0xe2a2ba347659e53c53f3089ff3268255842c03bafbbf185375f94c7a78f3f98a
+```
+
 <!-- <video width="100%" controls poster="/static/img/v1.3/calculatorPoster.png">
     <source src="/videos/Sunodo_Send.mp4" type="video/mp4" />
     Your browser does not support video tags.
@@ -278,6 +293,10 @@ sunodo send generic
 ## Retrieving outputs from the application
 
 The `sunodo send generic` sends a notice containing a payload to the Rollup Server's `/notice` endpoint.
+
+:::note querying noticees
+Notice payloads will be returned in hexadecimal format; developers will need to decode these to convert them into plain text.
+:::
 
 We can query these notices using the GraphQL playground hosted on `http://localhost:8080/graphql` or with a custom frontend client.
 
@@ -312,6 +331,8 @@ for (let edge of result.data.notices.edges) {
   let payload = edge.node.payload;
 }
 ```
+
+
 
 You can also [query a notice based on its input index](../development/retrieve-outputs.md/#query-a-single-notice).
 

--- a/cartesi-rollups/tutorials/machine-learning.md
+++ b/cartesi-rollups/tutorials/machine-learning.md
@@ -225,11 +225,7 @@ Your application is now ready to receive inputs.
 To interact with the application, provide the input in JSON. The input should include key-value pairs for specific features the ML model uses for prediction. Here’s an example:
 
 ```json
-{
-  "Age": 23,
-  "Sex": "female",
-  "Embarked": "S"
-}
+{ "Age": 37, "Sex": "male", "Embarked": "S" }
 ```
 
 The application responds with a predicted classification result, where 0 indicates the person did not survive, and 1 indicates survival.
@@ -240,10 +236,71 @@ To send inputs, run:
 sunodo send generic
 ```
 
+
+Example: Send an input to the application.
+
+```shell
+> sunodo send generic
+? Chain Foundry
+? RPC URL http://127.0.0.1:8545
+? Wallet Mnemonic
+? Mnemonic test test test test test test test test test test test junk
+? Account 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 9999.970671818064986684 ETH
+? Application address 0xab7528bb862fb57e8a2bcd567a2e929a0be56a5e
+? Input String encoding
+? Input (as string) { "Age": 37, "Sex": "male", "Embarked": "S" }
+✔ Input sent: 0xe2a2ba347659e53c53f3089ff3268255842c03bafbbf185375f94c7a78f3f98a
+```
+
 <!-- <video width="100%" controls poster="/static/img/v1.3/calculatorPoster.png">
     <source src="/videos/M_Cgen.mp4" type="video/mp4" />
     Your browser does not support video tags.
 </video> -->
+
+## Retrieving outputs 
+
+The `sunodo send generic` sends a notice containing a payload to the Rollup Server's `/notice` endpoint.
+
+:::note querying noticees
+Notice payloads will be returned in hexadecimal format; developers will need to decode these to convert them into plain text.
+:::
+
+We can query these notices using the GraphQL playground hosted on `http://localhost:8080/graphql` or with a custom frontend client.
+
+You can retrieve all notices sent to the rollup server with the query:
+
+```graphql
+query notices {
+  notices {
+    edges {
+      node {
+        index
+        input {
+          index
+        }
+        payload
+      }
+    }
+  }
+}
+```
+
+Alternatively, you can query this on a frontend client:
+
+```js
+const response = await fetch("http://localhost:8080/graphql", {
+  method: "POST",
+  headers: { "Content-Type": "application/json" },
+  body: '{ "query": "{ notices { edges { node { payload } } } }" }',
+});
+const result = await response.json();
+for (let edge of result.data.notices.edges) {
+  let payload = edge.node.payload;
+}
+```
+
+
+
 
 ## Changing the application
 

--- a/cartesi-rollups/tutorials/python-wallet.md
+++ b/cartesi-rollups/tutorials/python-wallet.md
@@ -29,11 +29,17 @@ pip install cartesi-wallet
 You must compile some source code for this lib to run on Docker. Include `build-essential` in your Dockerfile in the apt-get install. Like this:
 
 ```dockerfile
-apt-get install -y --no-install-recommends build-essential=12.9ubuntu3 busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.15
+apt-get install -y --no-install-recommends build-essential=12.9ubuntu3 busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.16
 ```
 
 
 ## Usage
+
+Add the `cartesi-wallet` module to your `requirements.txt` file:
+
+```shell
+cartesi-wallet == 0.0.4
+```
 
 To use the `cartesi-wallet` module in your project, you need to import the module and necessary utilities:
 
@@ -103,6 +109,9 @@ Below is an example of `ERC20` transfer and withdrawal:
 ```python 
 msg_sender = data["metadata"]["msg_sender"]
 payload = data["payload"]
+
+def decode_json(data):
+    return json.loads(hex_to_str(data))
 
 try:
     req_json = decode_json(payload)
@@ -198,7 +207,12 @@ erc721_portal_address = "0x237F8DD094C0e47f4236f12b4Fa01d6Dae89fb87"
 
 wallet = Wallet
 rollup_address = ""
+
+# define a function to convert a hexadecimal string to a json
+def decode_json(data):
+    return json.loads(hex_to_str(data))
 ```
+
 
 
 ### Ether
@@ -257,6 +271,7 @@ def handle_advance(data):
     logger.info(f"Received advance request data {data}")
     msg_sender = data["metadata"]["msg_sender"]
     payload = data["payload"]
+
     
     # Deposit      
     try:


### PR DESCRIPTION
## Activities
- Added a Node.js install step to Quickstart and Installation pages
- Added a summary for the services being run from the command: `sunodo run`
- Fixed typos and reformatted troubleshooting "appearance"
- Added a `decode_json` function to the `python-wallet tutorial`
- Added sample code examples to `calculator` and `machine learning` tutorials
- Added a paragraph to elaborate on "Dave" role in Cartesi Rollups

## Evidence
https://docs-azure-two.vercel.app/cartesi-rollups/1.3/