### PR TITLE
Transition from Sunodo CLI to Cartesi CLI

### DIFF
--- a/cartesi-rollups/deployment/introduction.md
+++ b/cartesi-rollups/deployment/introduction.md
@@ -11,13 +11,11 @@ To facilitate the instantiation of such nodes, Cartesi provides an infrastructur
 
 The Cartesi rollups node is distributed as a Docker image. Any popular cloud provider, like AWS, GCP, Azure, Digital Ocean, or Linode, can run docker containers and hence can be used to host the rollups node. 
 
-
 ## Deployment process
 
 The deployment of an application involves building a Cartesi machine and deploying a smart contract to a supported network.
 
-The `sunodo build` command produces the Cartesi genesis machine, which contains a hash representing the application and its initial state. 
-
+The `cartesi build` command produces the Cartesi genesis machine, which contains a hash representing the application and its initial state.
 
 After deployment, any changes to the application code will generate a different hash and, hence, require another deployment.
 

--- a/cartesi-rollups/deployment/self-hosted.md
+++ b/cartesi-rollups/deployment/self-hosted.md
@@ -27,14 +27,14 @@ Here are the requirements:
 
 1. Compile your application into RISC-V architecture and consequently build a Cartesi machine by running:
 
-   ```
-    sunodo build
+   ```shell
+    cartesi build
    ```
 
 2. Run the command below to start the deployment process.
 
-   ```
-     sunodo deploy --hosting self-hosted
+   ```shell
+     cartesi deploy --hosting self-hosted --webapp https://sunodo.io/deploy
    ```
 
   The command generates a Docker image containing the rollups node and machine. You will be redirected to a web application to deploy the necessary smart contracts.
@@ -112,7 +112,7 @@ Alternatively, you can use a service like [Fly.io](https://fly.io/) to deploy yo
 Fly.io is a platform where you can conveniently deploy applications packaged as Docker containers.
 
 :::caution important
-If deploying to Fly.io from macOS with Apple Silicon, create a Docker image for `linux/amd64` with: `sunodo deploy build --platform linux/amd64`
+If deploying to Fly.io from macOS with Apple Silicon, create a Docker image for `linux/amd64` with: `cartesi deploy build --platform linux/amd64`
 :::
 
 1. [Install the flyctl CLI](https://fly.io/docs/hands-on/install-flyctl/)

--- a/cartesi-rollups/development/building-the-application.md
+++ b/cartesi-rollups/development/building-the-application.md
@@ -8,7 +8,7 @@ title: Building the application
 With the Docker engine running, change the directory to your application and build by running:
 
 ```shell
-sunodo build
+cartesi build
 ```
 
 The successful execution of this step will log this in your terminal:
@@ -36,7 +36,5 @@ Manual yield rx-accepted (0x100000000 data)
 Cycles: 2767791744
 2767791744: b740d27cf75b6cb10b1ab18ebd96be445ca8011143d94d8573221342108822f5
 Storing machine: please wait
-Successfully copied 288MB to /Users/michaelasiedu/Code/calculator/python/.sunodo/image
+Successfully copied 288MB to /Users/michaelasiedu/Code/calculator/python/.cartesi/image
 ```
-
-

--- a/cartesi-rollups/development/creating-application.md
+++ b/cartesi-rollups/development/creating-application.md
@@ -3,16 +3,16 @@ id: creating-application
 title: Creating an application
 ---
 
-Sunodo simplifies creating dApps on Cartesi. To create a new application, run:
+Cartesi CLI simplifies creating dApps on Cartesi. To create a new application, run:
 
 ```shell
-sunodo create <dapp-name> --template <language>
+cartesi create <dapp-name> --template <language>
 ```
 
 For example, create a Python project.
 
-```
-sunodo create new-dapp --template python
+```shell
+cartesi create new-dapp --template python
 ```
 
 This command creates a `new-dapp` directory with essential files for your dApp development.
@@ -25,7 +25,6 @@ This command creates a `new-dapp` directory with essential files for your dApp d
 
 - `requirements.txt`: Lists the Python dependencies required for your application.
 
-Sunodo has templates for the following languages – `cpp`, `cpp-low-level`, `go`, `javascript`, `lua`, `python`, `ruby`, `rust`, and `typescript`.
+Cartesi CLI has templates for the following languages – `cpp`, `cpp-low-level`, `go`, `javascript`, `lua`, `python`, `ruby`, `rust`, and `typescript`.
 
 After creating your application, you can start building your dApp by adding your logic to the `dapp.py` file.
-

--- a/cartesi-rollups/development/installation.md
+++ b/cartesi-rollups/development/installation.md
@@ -3,9 +3,9 @@ id: installation
 title: Installation
 ---
 
-The primary requirements for building on Cartesi are Sunodo and Docker Desktop for your operating system of choice.
+The primary requirements for building on Cartesi are the Cartesi CLI and Docker Desktop for your operating system of choice.
 
-Sunodo is an easy-to-use CLI tool with which you can develop and deploy your dApps without getting lost in intricate commands and configurations of Docker and the node itself.
+Cartesi CLI is an easy-to-use tool with which you can develop and deploy your dApps without getting lost in intricate commands and configurations of Docker and the node itself.
 
 Docker is the required tool to distribute the Cartesi Rollups framework and its dependencies.
 
@@ -21,18 +21,20 @@ Follow [the instructions here to install Docker Desktop](https://www.docker.com/
 :::troubleshoot troubleshooting common errors
 
 #### Error: Invalid image Architecture
-```
+```shell
 Error: Invalid image Architecture: Expected riscv64
 ```
 
 #### Solution:
 
+```shell
 1. Check if your Docker supports the RISCV platform by running:
 
   ```
   docker buildx ls
   ```
 
+```shell
 2. If you do not see `linux/riscv64` in the platforms list, install `QEMU` by running:
 
   ```
@@ -50,35 +52,35 @@ After downloading, run the installer and follow the instructions to complete the
 
 Verify the installation by running `node -v`, which will display the version of Node.js that was installed.
 
-## Install Sunodo
+## Install Cartesi CLI
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 <Tabs>
   <TabItem value="macOS" label="macOS" default>
-  <p>Install Sunodo with Homebrew:</p>
+  <p>Install Cartesi CLI with Homebrew:</p>
     <pre><code>
-    brew install sunodo/tap/sunodo
+    brew install cartesi/tap/cartesi
     </code></pre>
-    <p> Alternatively, you can use Node.js to install Sunodo:</p>
+    <p> Alternatively, you can use Node.js to install Cartesi CLI:</p>
     <pre><code>
-    npm install -g @sunodo/cli
+    npm install -g @cartesi/cli
     </code></pre>
   </TabItem>
 
   <TabItem value="Linux" label="Linux">
-  <p>Install Sunodo with Node.js:</p>
+  <p>Install Cartesi CLI with Node.js:</p>
     <pre><code>
-    npm install -g @sunodo/cli
+    npm install -g @cartesi/cli
     </code></pre>
   </TabItem>
 
   <TabItem value="Windows" label="Windows">
     <p>1. Install <a href="https://learn.microsoft.com/en-us/windows/wsl/install">WSL2</a> and Ubuntu from the Microsoft store</p>
-    <p>2. Install Sunodo with Node.js </p>
+    <p>2. Install Cartesi CLI with Node.js </p>
     <pre><code>
-    npm install -g @sunodo/cli
+    npm install -g @cartesi/cli
     </code></pre>
   </TabItem>
 </Tabs>
@@ -87,9 +89,9 @@ import TabItem from '@theme/TabItem';
 For a seamless development workflow on Windows, do not execute Docker commands within Powershell. Instead, open the latest Ubuntu terminal that you have installed and perform all coding and command execution within that Linux environment.
 :::
 
-Sunodo Doctor is a diagnostic tool that declares whether your system is ready and set up for development.
+Cartesi CLI doctor is a diagnostic tool that declares whether your system is ready and set up for development.
 
 ```shell
-$ sunodo doctor
-✔ Your system is ready for sunodo.
+$ cartesi doctor
+✔ Your system is ready for cartesi.
 ```

--- a/cartesi-rollups/development/node-configuration.md
+++ b/cartesi-rollups/development/node-configuration.md
@@ -1,19 +1,16 @@
 ---
 id: node-configuration
 title: Node configuration
-resources:
-  - url: https://docs.sunodo.io/guide/running/running-application
-    title: Node configuration with Sunodo
 ---
 
-Sunodo comes pre-configured with some default settings for Cartesi nodes. You can configure epoch duration, block time, environment variables, memory and the content of the information you want your node to preview.
+Cartesi CLI comes pre-configured with some default settings for Cartesi nodes. You can configure epoch duration, block time, environment variables, memory and the content of the information you want your node to preview.
 
 ## Verbosity
 
 By default, the node works in non-verbose mode and only outputs logs from the user’s backend application. In case the user needs more information, there is the `--verbose` flag.
 
-```
-sunodo run --verbose
+```shell
+cartesi run --verbose
 ```
 
 ## Block time
@@ -24,8 +21,8 @@ By default, the node processes a block every 5 seconds.
 
 You can configure the block time by running:
 
-```
-sunodo run --block-time <seconds>
+```shell
+cartesi run --block-time <seconds>
 ```
 
 ## Epoch duration
@@ -42,11 +39,10 @@ One everyday use of vouchers in Cartesi dApps is to withdraw assets.
 
 A voucher can only be executed once the dApp's consensus submits a claim containing it, i.e., when their corresponding epoch is closed.
 
-
 To change the default epoch duration, run:
 
-```
-sunodo run --epoch-duration <seconds>
+```shell
+cartesi run --epoch-duration <seconds>
 ```
 
 ## Memory
@@ -60,5 +56,5 @@ LABEL io.cartesi.rollups.ram_size=128Mi
 ```
 
 :::note environment variables
-You can create a `.sunodo.env` in the project's root and override any variable controlling the rollups-node.
+You can create a `.cartesi.env` in the project's root and override any variable controlling the rollups-node.
 :::

--- a/cartesi-rollups/development/retrieve-outputs.md
+++ b/cartesi-rollups/development/retrieve-outputs.md
@@ -154,7 +154,7 @@ def handle_advance(data):
 
 </Tabs>
 
-For example, sending an input payload of `“2”` to the application using Cast or `sunodo send generic` will log:
+For example, sending an input payload of `“2”` to the application using Cast or `cartesi send generic` will log:
 
 ```bash
 Received finish status 200

--- a/cartesi-rollups/development/running-the-application.md
+++ b/cartesi-rollups/development/running-the-application.md
@@ -19,12 +19,12 @@ NoNodo is a light development tool that does not require Docker running and allo
 Here are the prerequisites to run the node in production mode:
 
 - Docker Engine must be active.
-- Cartesi machine snapshot successfully built with `sunodo build`.
+- Cartesi machine snapshot successfully built with `cartesi build`.
 
 To start the node in production mode:
 
-```
-sunodo run
+```shell
+cartesi run
 ```
 
 This command runs your backend compiled to RISC-V and packages it as a Cartesi machine.
@@ -32,7 +32,8 @@ This command runs your backend compiled to RISC-V and packages it as a Cartesi m
 :::troubleshoot troubleshooting common errors
 
 #### Error: Depth Too High
-```
+
+```shell
 Attaching to 2bd74695-prompt-1, 2bd74695-validator-1
 2bd74695-validator-1  | Error: DepthTooHigh { depth: 2, latest: 1 }
 2bd74695-validator-1  | Error: DepthTooHigh { depth: 2, latest: 1 }
@@ -40,20 +41,21 @@ Attaching to 2bd74695-prompt-1, 2bd74695-validator-1
 
 This indicates that the node is reading blocks too far behind the current blockchain state.
 
-#### Solution:
+#### Solution
 
-Create or modify a `.sunodo.env` file in your project directory and set:
+Create or modify a `.cartesi.env` file in your project directory and set:
 
-```
+```shell
 TX_DEFAULT_CONFIRMATIONS=1
 ```
+
 This adjustment should align the node's block reading with the blockchain's current state.
 
 :::
 
 ### Overview of Node Services
 
-The `sunodo run` command activates several services essential for node operation:
+The `cartesi run` command activates several services essential for node operation:
 
 - **Anvil Chain**: Runs a local blockchain available at `http://localhost:8545`.
 
@@ -62,7 +64,6 @@ The `sunodo run` command activates several services essential for node operation
 - **Blockchain Explorer**: Monitors node activity and manages transactions via `http://localhost:8080/explorer/`.
 
 - **Inspect**: A diagnostic tool accessible at `http://localhost:8080/inspect/` to inspect the node’s state.
-
 
 ## NoNodo (Testing & Development)
 
@@ -88,7 +89,7 @@ Install Go by following [the instructions on the official Go website](https://go
 
 Run the following command to install NoNodo:
 
-```
+```shell
 go install github.com/gligneul/nonodo@latest
 ```
 
@@ -98,7 +99,7 @@ Set `GOPATH` to use the NoNodo command directly.
 
 To use the NoNodo command directly, add it to the PATH variable by running:
 
-```
+```shell
 export PATH="$HOME/go/bin:$PATH"
 ```
 
@@ -106,11 +107,11 @@ export PATH="$HOME/go/bin:$PATH"
 
 To start NoNodo with the default configuration, run:
 
-```
+```shell
 nonodo
 ```
 
-This command creates an Anvil node with the Cartesi Rollups contracts deployed by default. NoNodo uses the same deployment as Sunodo, so the contract addresses remain the same.
+This command creates an Anvil node with the Cartesi Rollups contracts deployed by default. NoNodo uses the same deployment as the Cartesi CLI, so the contract addresses remain the same.
 
 ### Exposed APIs
 
@@ -126,7 +127,7 @@ NoNodo can run the application backend as a sub-process.
 
 This option helps keep the entire development in a single terminal. To use it, pass the command to run the application after `--`.
 
-```
+```shell
 nonodo -- ./my-app
 ```
 
@@ -138,7 +139,7 @@ The echo also generates a report for each inspected input. This option is useful
 
 To start NoNodo with the built-in echo application, use the `--enable-echo` flag.
 
-```
+```shell
 nonodo --enable-echo
 ```
 

--- a/cartesi-rollups/development/send-requests.md
+++ b/cartesi-rollups/development/send-requests.md
@@ -133,7 +133,7 @@ Every starter project you create has this base code as a template, ready to rece
 
 ### Initiate an advance request
 
-You can initiate an advance request by sending input from the CLI using Cast, Sunodo, or a custom frontend client.
+You can initiate an advance request by sending input from the CLI using Cast, Cartesi CLI, or a custom frontend client.
 
 Advance requests involve sending input data to the L1 through a JSON-RPC call, allowing the information to reach the dApp backend and trigger a change in the application's state.
 
@@ -147,7 +147,7 @@ In the dApp architecture, here is how an advance request plays out.
 
 - Step 3: After the computation, the state is updated, and the results are sent back to the rollup server.
 
-You can send inputs to your application with [Cast](https://book.getfoundry.sh/cast/), Sunodo, or a custom web interface. 
+You can send inputs to your application with [Cast](https://book.getfoundry.sh/cast/), Cartesi CLI, or a custom web interface.
 
 #### 1. Send inputs with Cast
 
@@ -159,22 +159,20 @@ This command sends the payload to the InputBox smart contract, initiating the ad
 
 Replace placeholders like `<InputBoxAddress>`, `<DAppAddress>`, `<EncodedPayload>`, and `<MNEMONIC>` with the actual addresses, payload, and mnemonic for your specific use case.
 
+You can obtain the relevant addresses by running `cartesi address-book`.
 
-You can obtain the relevant addresses by running `sunodo address-book`.
+#### 2. Send inputs with Cartesi CLI
 
-
-#### 2. Send inputs with Sunodo
-
-Sunodo provides a convenient way of sending inputs to a dApp.
+Cartesi CLI provides a convenient way of sending inputs to a dApp.
 
 To send an input, run:
 
-```
-sunodo send
+```shell
+cartesi send
 ```
 
-```
-$ sunodo send
+```shell
+$ cartesi send
 ? Select send sub-command (Use arrow keys)
 ❯ Send DApp address input to the application.
   Send ERC-20 deposit to the application.
@@ -188,7 +186,7 @@ There are five types of inputs using a sub-command: `dapp-address`, `erc20`, `er
 Unlike the asset-type sub-commands (Ether, ERC20, and ERC721), the generic input command allows you to send inputs with any payload format (hex, string, and ABI).
 
 ```shell
-$ sunodo send generic
+$ cartesi send generic
 ? Chain (Use arrow keys)
 ❯ Foundry
 ? Chain Foundry

--- a/cartesi-rollups/quickstart.md
+++ b/cartesi-rollups/quickstart.md
@@ -14,22 +14,22 @@ Welcome to Quickstart. Here is a step-by-step guide to building a decentralized 
 
 ## Set up your environment
 
-The primary requirements for building on Cartesi are Docker Desktop and Sunodo.
+The primary requirements for building on Cartesi are Docker Desktop and the Cartesi CLI.
 
 :::note windows os configuration
 If you use Windows, you must have [WSL2 installed and configured](https://learn.microsoft.com/en-us/windows/wsl/install) for building. In Docker Desktop settings, confirm that the WSL2-based engine configurations are enabled.
 :::
 
-### Install Docker Desktop and Sunodo
+### Install Docker Desktop and Cartesi CLI
 
 1. [Install Docker Desktop for your operating system](https://www.docker.com/products/docker-desktop/).
 
 1. [Download and install the latest version of Node.js](https://nodejs.org/en/download).
 
-2. Sunodo is an easy-to-use CLI tool to build and deploy your dApps. To install Sunodo, run:
+2. Cartesi CLI is an easy-to-use tool to build and deploy your dApps. To install it, run:
 
    ```shell
-    npm i -g @sunodo/cli
+    npm i -g @cartesi/cli
    ```
 
 ## Create an application
@@ -37,13 +37,13 @@ If you use Windows, you must have [WSL2 installed and configured](https://learn.
 To create the backend application from scratch, run:
 
 ```bash
-sunodo create <dapp-name> --template <language>
+cartesi create <dapp-name> --template <language>
 ```
 
 This creates a new directory with template code in the language you specify.
 
 ```bash
-$ sunodo create js-dapp --template javascript
+$ cartesi create js-dapp --template javascript
 ✔ Application created at /js-dapp
 ```
 
@@ -56,10 +56,10 @@ To build your application, ensure you have Docker Desktop running.
 After that, you can run the command provided below:
 
 ```bash
-sunodo build
+cartesi build
 ```
 
-The `sunodo build` command builds a Cartesi machine and compiles your application so that it is ready to receive requests and inputs.
+The `cartesi build` command builds a Cartesi machine and compiles your application so that it is ready to receive requests and inputs.
 
 ## Run the application
 
@@ -67,29 +67,29 @@ Running your application starts a local Anvil node on port `8545`.
 
 To run your application:
 
-```
-sunodo run
+```shell
+cartesi run
 ```
 
 ## Send inputs to the application
 
-You have some options available for sending inputs to your application. One option is the `sunodo send` command.
+You have some options available for sending inputs to your application. One option is the `cartesi send` command.
 
 Another option is [Cast](https://book.getfoundry.sh/cast/), a command-line tool enabling you to make Ethereum RPC calls.
 
 Additionally, you can build a custom web interface to input data into your application.
 
-### Using Sunodo
+### Using Cartesi CLI
 
 Here is how you can send input to your dApp:
 
 ```shell
-sunodo send
+cartesi send
 ```
 
-This guides you through sending inputs with Sunodo interactively.
+This guides you through sending inputs with the CLI interactively.
 
-```
+```shell
 ? Select the send sub-command (Use arrow keys)
 ❯ Send DApp address input to the application.
   Send ERC-20 deposit to the application.
@@ -111,7 +111,7 @@ This command sends an input payload to your application through the `InputBox` c
 Replace placeholders like `<InputBoxAddress>`, `<DAppAddress>`, `<EncodedPayload>`, and `<MNEMONIC>` with the actual addresses, payload, and mnemonic for your specific use case.
 
 
-You can obtain the relevant addresses by running `sunodo address-book`.
+You can obtain the relevant addresses by running `cartesi address-book`.
 
 ### Using a custom web interface
 

--- a/cartesi-rollups/tutorials/calculator.md
+++ b/cartesi-rollups/tutorials/calculator.md
@@ -18,7 +18,7 @@ The backend will be written using Python. For added flexibility, feel free to ex
 
 Install these to set up your environment for quick building:
 
-- Sunodo: A simple tool for building applications on Cartesi. [Install Sunodo for your OS of choice](../development/installation.md).
+- Cartesi CLI: A simple tool for building applications on Cartesi. [Install Cartesi CLI for your OS of choice](../development/installation.md).
 
 - Docker Desktop: The tool you need to run the Cartesi Machine and its dependencies. [Install Docker for your OS of choice](https://www.docker.com/products/docker-desktop/).
 
@@ -29,7 +29,7 @@ Install these to set up your environment for quick building:
 To create a backend application with Python, run:
 
 ```shell
-sunodo create calculator --template python
+cartesi create calculator --template python
 ```
 
 This creates a `calculator/` directory with essential files for your Python development.
@@ -246,7 +246,7 @@ while True:
 With Docker running, “build your backend” application by running:
 
 ```shell
-sunodo build
+cartesi build
 ```
 
 “Building” in this context installs the libraries in the `requirements.txt`, compiles your application into RISC-V architecture, and consequently builds a Cartesi machine that contains your backend application.
@@ -256,24 +256,24 @@ The anvil node can now run your application.
 
 To run your application, enter the command:
 
-```
-sunodo run
+```shell
+cartesi run
 ```
 
 ### Sending inputs with the CLI
 
-We can send inputs to our application with a custom JavaScript frontend, Cast, or Sunodo.
+We can send inputs to our application with a custom JavaScript frontend, Cast, or Cartesi CLI.
 
 To send generic inputs to our application quickly, run the following:
 
 ```shell
-sunodo send generic
+cartesi send generic
 ```
 
 Example: Send `1+2` as an input to the application.
 
 ```shell
-> sunodo send generic
+> cartesi send generic
 ? Chain Foundry
 ? RPC URL http://127.0.0.1:8545
 ? Wallet Mnemonic
@@ -292,7 +292,7 @@ Example: Send `1+2` as an input to the application.
 
 ## Retrieving outputs from the application
 
-The `sunodo send generic` sends a notice containing a payload to the Rollup Server's `/notice` endpoint.
+The `cartesi send generic` sends a notice containing a payload to the Rollup Server's `/notice` endpoint.
 
 :::note querying noticees
 Notice payloads will be returned in hexadecimal format; developers will need to decode these to convert them into plain text.
@@ -337,4 +337,3 @@ for (let edge of result.data.notices.edges) {
 You can also [query a notice based on its input index](../development/retrieve-outputs.md/#query-a-single-notice).
 
 Congratulations, you have successfully built a dApp on Cartesi Rollups!
-

--- a/cartesi-rollups/tutorials/javascript-wallet.md
+++ b/cartesi-rollups/tutorials/javascript-wallet.md
@@ -22,20 +22,19 @@ Let’s build a simple dApp that uses the `cartesi-wallet` package to handle dif
 
 [Cartesi Wallet](https://github.com/jjhbk/cartesi-wallet) is a JavaScript/TypeScript-based wallet implementation for Cartesi dApps.
 
-
 ## Installation
 
 1. Create a backend application by running:
 
-```shell
-sunodo create js-wallet-dapp --template javascript
-```
+    ```shell
+    cartesi create js-wallet-dapp --template javascript
+    ```
 
 2. In the `js-wallet-dapp` directory, install `cartesi-wallet,` and `viem`.
 
-```shell
-npm install viem cartesi-wallet
-```
+    ```shell
+    npm install viem cartesi-wallet
+    ```
 
 ## Usage
 
@@ -52,7 +51,6 @@ Create an instance of the Wallet by initializing it with an empty Map object:
 let wallet = new Wallet(new Map());
 ```
 
-
 Initialize variables for the portal contract and relay addresses:
 
 ```js
@@ -62,14 +60,11 @@ const erc721PortalAddress = "0x...87";
 const dAppAddressRelayContract = "0x...aE";
 ```
 
-You can obtain the relevant addresses by running `sunodo address-book`.
-
-
+You can obtain the relevant addresses by running `cartesi address-book`.
 
 ## Implementing Deposits
 
 In the application entry point’s `handle_advance()` function, create instances for depositing various asset types to our dApp.
-
 
 ```js
 if (data.metadata.msg_sender.toLowerCase() == erc20PortalAddress.toLowerCase()) {

--- a/cartesi-rollups/tutorials/machine-learning.md
+++ b/cartesi-rollups/tutorials/machine-learning.md
@@ -6,27 +6,27 @@ resources:
       title: Source code for the m2cgen application
 ---
 
-In this machine learning tutorial, we will predict a classification based on the Titanic dataset, which shows the characteristics of people onboard the Titanic and whether those people survived the disaster. 
+In this machine learning tutorial, we will predict a classification based on the Titanic dataset, which shows the characteristics of people onboard the Titanic and whether those people survived the disaster.
 
 You can submit inputs describing a person's features to determine if that person is likely to have survived.
 
-## Set up your environment.
+## Set up your environment
+
 Install these to set up your environment for quick building.
 
-- Sunodo is a simple tool for building applications on Cartesi. [Install Sunodo for your OS of choice](../development/installation.md).
+- Cartesi CLI is a simple tool for building applications on Cartesi. [Install Cartesi CLI for your OS of choice](../development/installation.md).
 
 - Docker Desktop is the tool you need to run the Cartesi Machine and its dependencies. [Install Docker](https://www.docker.com/products/docker-desktop/).
 
 - Python: This is used to write your backend application logic. [Install Python3](https://www.python.org/downloads/).
 
-
 ## Understanding the dApp
 
-- ML Model Generation: The dApp generates a logistic regression model using sci-kit-learn, NumPy, and pandas. 
+- ML Model Generation: The dApp generates a logistic regression model using sci-kit-learn, NumPy, and pandas.
 
-- m2cgen Transpilation: The dApp uses the m2cgen (Model to Code Generator) library to transpile the ML model into pure Python code without external dependencies. This translation simplifies the execution process, particularly in the Cartesi Machine environment. 
+- m2cgen Transpilation: The dApp uses the m2cgen (Model to Code Generator) library to transpile the ML model into pure Python code without external dependencies. This translation simplifies the execution process, particularly in the Cartesi Machine environment.
 
-The practical goal of the application is to predict a classification based on the Titanic dataset. 
+The practical goal of the application is to predict a classification based on the Titanic dataset.
 
 Users can submit inputs describing a person’s features (e.g., age, sex, embarked port), and the application predicts whether that person is likely to have survived the Titanic disaster.
 
@@ -50,13 +50,11 @@ Clone the repo for this project, and let’s go through it:
 git clone https://github.com/Mugen-Builders/m2cgen.git
 ```
 
+The `m2cgen` folder contains a model folder with a Python script and a `requirements.txt` file.
 
-The `m2cgen` folder contains a model folder with a Python script and a `requirements.txt` file. 
-
-The `build_model.py` file contains the logic for creating the model for our solution, while the requirements.txt contains the libraries needed for the script. 
+The `build_model.py` file contains the logic for creating the model for our solution, while the requirements.txt contains the libraries needed for the script.
 
 You can think of the `build_model.py` as a jupyter-notebook file, which we experiment with and create models before using. Let's look at what the `build_model.py` does.
-
 
 ```python
 import pandas as pd
@@ -97,7 +95,6 @@ with open("model.py", "w") as text_file:
 
 print("Model exported successfully")
 ```
-
 
 The script primarily aims to export and prepare the ML model for integration into our Cartesi application. It includes the necessary libraries and functions to read data, preprocess it, train a model, and export it to a `model.py` file.
 
@@ -194,13 +191,13 @@ while True:
         finish["status"] = handler(rollup_request["data"])
 ```
 
-This script is the core of our application, responsible for interacting with the Cartesi Rollups infrastructure. 
+This script is the core of our application, responsible for interacting with the Cartesi Rollups infrastructure.
 
-It leverages the pre-trained Machine Learning model we create with the `build_model.py` script and receives input data from the Cartesi Rollup server. 
+It leverages the pre-trained Machine Learning model we create with the `build_model.py` script and receives input data from the Cartesi Rollup server.
 
-The script then processes this data, applies the model to make predictions, and communicates the results to the Rollup server. 
+The script then processes this data, applies the model to make predictions, and communicates the results to the Rollup server.
 
-The primary functions of this script include data conversion, model prediction, and communication with the Cartesi infrastructure. It ensures our ML-based application seamlessly integrates into Cartesi’, allowing us to harness the power of machine learning within the blockchain environment. 
+The primary functions of this script include data conversion, model prediction, and communication with the Cartesi infrastructure. It ensures our ML-based application seamlessly integrates into Cartesi’, allowing us to harness the power of machine learning within the blockchain environment.
 
 Now, let’s build and send inputs to the application.
 
@@ -209,13 +206,13 @@ Now, let’s build and send inputs to the application.
 To build the container of the m2cgen is very straightforward. Run:
 
 ```shell
-sunodo build
+cartesi build
 ```
 
 After the build process is complete, run the node with the command:
 
 ```shell
-sunodo run
+cartesi run
 ```
 
 Your application is now ready to receive inputs.
@@ -233,14 +230,14 @@ The application responds with a predicted classification result, where 0 indicat
 To send inputs, run:
 
 ```shell
-sunodo send generic
+cartesi send generic
 ```
 
 
 Example: Send an input to the application.
 
 ```shell
-> sunodo send generic
+> cartesi send generic
 ? Chain Foundry
 ? RPC URL http://127.0.0.1:8545
 ? Wallet Mnemonic
@@ -257,9 +254,9 @@ Example: Send an input to the application.
     Your browser does not support video tags.
 </video> -->
 
-## Retrieving outputs 
+## Retrieving outputs
 
-The `sunodo send generic` sends a notice containing a payload to the Rollup Server's `/notice` endpoint.
+The `cartesi send generic` sends a notice containing a payload to the Rollup Server's `/notice` endpoint.
 
 :::note querying noticees
 Notice payloads will be returned in hexadecimal format; developers will need to decode these to convert them into plain text.
@@ -315,4 +312,3 @@ To change those, open the file `model/build_model.py` and change the following v
 - `include`: an optional list indicating a subset of the dataset's features to be used in the prediction model.
 
 - `dependent_var`: the feature to be predicted, such as the entry's classification.
-

--- a/cartesi-rollups/tutorials/python-wallet.md
+++ b/cartesi-rollups/tutorials/python-wallet.md
@@ -32,7 +32,6 @@ You must compile some source code for this lib to run on Docker. Include `build-
 apt-get install -y --no-install-recommends build-essential=12.9ubuntu3 busybox-static=1:1.30.1-7ubuntu3 ca-certificates=20230311ubuntu0.22.04.1 curl=7.81.0-1ubuntu1.16
 ```
 
-
 ## Usage
 
 Add the `cartesi-wallet` module to your `requirements.txt` file:
@@ -64,8 +63,8 @@ ether_portal_address = "0x...44"
 erc20_portal_address = "0x...DB"
 erc721_portal_address = "0x...87"
 ```
-You can obtain the relevant addresses by running `sunodo address-book`.
 
+You can obtain the relevant addresses by running `cartesi address-book`.
 
 ## Checking Balance
 
@@ -100,13 +99,11 @@ return "accept"
 
 ```
 
-
 ### Transfers and Withdrawals
 
 Below is an example of `ERC20` transfer and withdrawal:
 
-
-```python 
+```python
 msg_sender = data["metadata"]["msg_sender"]
 payload = data["payload"]
 
@@ -263,7 +260,6 @@ def handle_advance(data):
         return "reject"
 ```
 
-
 ### ERC20
 
 ```python
@@ -304,7 +300,6 @@ def handle_advance(data):
         logger.debug(error_msg, exc_info=True)
         return "reject"
 ```
-
 
 ### ERC721
 
@@ -384,34 +379,33 @@ def handle_inspect(data):
         return "reject"
 ```
 
-
 The routes for the Balance inspects implemented above are as follows:
 
 #### Ether
+
 ```shell
 balance/ether/{wallet}
 balance/ether/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 ```
 
+#### ERC20
 
-#### ERC20:
 ```shell
 balance/ether/{wallet}/{token_address}
 balance/erc20/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266/0xae7f61eCf06C65405560166b259C54031428A9C4
 ```
 
-#### ERC721:
+#### ERC721
+
 ```shell
 balance/ether/{wallet}/{token_addres}/{token_id}
 balance/erc721/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266/0xae7f61eCf06C65405560166b259C54031428A9C4/0
 ```
 
-
-##  Frontend Integration
+## Frontend Integration
 
 You can use a couple of options for frontend integration in your backend wallet. 
 
 - Frontend Console: The terminal can interact directly with your backend wallet. Here is [a sample frontend console application](https://github.com/Mugen-Builders/sunodo-frontend-console) ready to be used!
 
 - Web User Interface: Alternatively, you can develop a user-friendly web interface for your dApp. This approach offers a more polished user experience and is suitable for production-ready applications. Here are [React.js starter](https://github.com/Mugen-Builders/frontend-cartesi-wallet-x) and [Angular starter](https://github.com/jplgarcia/cartesi-angular-frontend) templates you can use.
-

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,10 +106,6 @@ const config = {
           //   position: "left",
           //   items: [
           //     {
-          //       label: "Sunodo",
-          //       href: "https://docs.sunodo.io/guide/introduction/what-is-sunodo",
-          //     },
-          //     {
           //       label: "NoNodo",
           //       href: "https://github.com/gligneul/nonodo/blob/main/README.md",
           //     },


### PR DESCRIPTION
This changes all references from Sunodo CLI to Cartesi CLI.
It must be merged only after Cartesi CLI is shipped. Which is expected to happen this week.

I'm not sure if we should create another version in the versioned docs.

ps: I also fixed some linting errors.