### PR TITLE
Redirects for broken links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -373,6 +373,47 @@ const config = {
             to: "/cartesi-rollups/1.3/", // Redirects /cartesi-rollups/ to the latest version
             from: "/cartesi-rollups/",
           },
+          {
+            to: "/cartesi-machine/",
+            from: ["/machine/", "/machine/intro/"],
+          },
+
+          {
+            to: "/cartesi-machine/host/",
+            from: ["/machine/host/"],
+          },
+          {
+            to: "/cartesi-machine/host/cmdline/",
+            from: ["/machine/host/cmdline/"],
+          },
+          {
+            to: "/cartesi-machine/host/lua/",
+            from: ["/machine/host/lua/"],
+          },
+          {
+            to: "/cartesi-machine/target/",
+            from: ["/machine/target/"],
+          },
+          {
+            to: "/cartesi-machine/target/linux/",
+            from: ["/machine/target/linux/"],
+          },
+          {
+            to: "/cartesi-machine/target/architecture/",
+            from: ["/machine/target/architecture/"],
+          },
+          {
+            to: "/cartesi-machine/blockchain/",
+            from: ["/machine/blockchain/"],
+          },
+          {
+            to: "/cartesi-machine/blockchain/hash/",
+            from: ["/machine/blockchain/hash"],
+          },
+          {
+            to: "/cartesi-machine/blockchain/vg/",
+            from: ["/machine/blockchain/vg/"],
+          },
         ],
         createRedirects(existingPath) {
           if (existingPath.includes("/cartesi-rollups/1.0/")) {


### PR DESCRIPTION
## Problem
- Broken links as a result of changing the machine docs base URL from `/machine` to `/cartesi-machine`

## Fix
- Redirects implemented to make sure people who visit via `/machine` get redirected to `/cartesi-machine` base url.

## Preview links
https://docs-azure-two.vercel.app/machine/
https://docs-azure-two.vercel.app/machine/intro
https://docs-azure-two.vercel.app/machine/host/cmdline/
https://docs-azure-two.vercel.app/machine/target/
https://docs-azure-two.vercel.app/machine/host/lua/
https://docs-azure-two.vercel.app/machine/target/linux/
https://docs-azure-two.vercel.app/machine/target/architecture/
https://docs-azure-two.vercel.app/machine/blockchain/
https://docs-azure-two.vercel.app/machine/blockchain/hash
https://docs-azure-two.vercel.app/machine/blockchain/vg/
