### PR TITLE
Update GraphQL API reference

### DIFF
--- a/cartesi-rollups/core-concepts/architecture.md
+++ b/cartesi-rollups/core-concepts/architecture.md
@@ -17,7 +17,7 @@ The Cartesi Rollups framework comprises two main parts: **the on-chain base laye
 
 A dApp running on Cartesi consists of the following main components:
 
-- [Cartesi Rollups](./optimistic-rollups.md/#cartesi-rollups), a set of on-chain and off-chain components that implement an Optimistic Rollup solution and provide the general framework for building dApps.
+- [Cartesi Rollups](./optimistic-rollups.md/), a set of on-chain and off-chain components that implement an Optimistic Rollup solution and provide the general framework for building dApps.
 
 - [Cartesi Machine](./cartesi-machine.md), a virtual machine (VM) that runs an entire Linux OS, in which a dApp's backend is executed.
 

--- a/cartesi-rollups/development/retrieve-outputs.md
+++ b/cartesi-rollups/development/retrieve-outputs.md
@@ -224,9 +224,7 @@ async function fetchNotices() {
 fetchNotices();
 ```
 
-### Query a single notice
-
-You can get a notice based on its index.
+You can get notices based on their `inputIndex`:
 
 Input your query in the left pane.
 
@@ -301,7 +299,9 @@ for (let edge of result.data.input.notices.edges) {
 }
 ```
 
-You can also fetch detailed information about a notice, including its proof information.
+### Query a single notice
+
+You can retrieve detailed information about a notice, including its proof information:
 
 Here is the query which takes two variables: `noticeIndex` and `inputIndex`.
 
@@ -429,11 +429,10 @@ query reports {
 
 Click the "Play" button (a triangular icon). The Playground will send the request to the server, and you'll see the response in the right pane.
 
-### Query a single report
 
-You can get a report based on its index.
+You can retrieve reports based on their `inputIndex`.
 
-Input your query in the left pane.
+Input your query in the left pane:
 
 ```graphql
 query reportsByInput($inputIndex: Int!) {
@@ -463,8 +462,9 @@ Then, in the bottom-left corner of the Playground, you'll find a section that pr
 
 Replace `123` with the value you want to pass for `$inputIndex`.
 
+### Query a single report
 
-You can also fetch information about a report with its `reportIndex` and `inputIndex`.
+You can retrieve a report with its `reportIndex` and `inputIndex`.
 
 ```graphql
 query report($reportIndex: Int!, $inputIndex: Int!) {

--- a/cartesi-rollups/development/retrieve-outputs.md
+++ b/cartesi-rollups/development/retrieve-outputs.md
@@ -303,7 +303,7 @@ for (let edge of result.data.input.notices.edges) {
 
 You can also fetch detailed information about a notice, including its proof information.
 
-Here is the query which takes two variables: noticeIndex and inputIndex.
+Here is the query which takes two variables: `noticeIndex` and `inputIndex`.
 
 ```graphql
 query notice($noticeIndex: Int!, $inputIndex: Int!) {

--- a/cartesi-rollups/rollups-apis/graphql/queries/input.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/input.mdx
@@ -4,8 +4,7 @@ title: input
 hide_table_of_contents: false
 ---
 
-
-Get input based on its identifier
+Get input based on its identifier:
 
 ```graphql
 input(
@@ -13,16 +12,33 @@ input(
 ): Input!
 ```
 
-
-### Arguments
+## Arguments
 
 #### `index` ([`Int!`](../../scalars/int))
 
-
-
-
-### Type
+## Type
 
 #### [`Input`](../../objects/input)
 
-Request submitted to the application to advance its state
+Request submitted to the application to advance its state.
+
+## Example usage
+
+1. Get an input based on its `inputIndex`:
+
+  ```graphql
+  query inputByIndex($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      index
+      payload
+    }
+  }
+  ```
+
+  ```graphql
+  {
+    "inputIndex": 0
+  }
+  ```
+
+  In this example, the query is set to retrieve the input at `inputIndex` `0`.

--- a/cartesi-rollups/rollups-apis/graphql/queries/inputs.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/inputs.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get inputs with support for pagination
+Get inputs with support for pagination:
 
 ```graphql
 inputs(
@@ -18,26 +18,26 @@ inputs(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `first` ([`Int`](../../scalars/int))
-Get at most the first `n` entries (forward pagination)
+Get at most the first `n` entries(forward pagination).
 
 
 
 
 #### `last` ([`Int`](../../scalars/int))
-Get at most the last `n` entries (backward pagination)
+Get at most the last `n` entries(backward pagination).
 
 
 
 #### `after` ([`String`](../../scalars/string))
-Get entries that come after the provided cursor (forward pagination)
+Get entries that come after the provided cursor(forward pagination).
 
 
 
 #### `before` ([`String`](../../scalars/string))
-Get entries that come before the provided cursor (backward pagination)
+Get entries that come before the provided cursor(backward pagination).
 
 
 
@@ -46,8 +46,26 @@ Get entries that come before the provided cursor (backward pagination)
 
 
 
-### Type
+## Type
 
 #### [`InputConnection`](../../objects/input-connection)
 
-Pagination result
+Pagination result.
+
+
+## Example usage
+
+1. Query all inputs:
+
+  ```graphql
+  query inputs {
+    inputs {
+      edges {
+        node {
+          index
+          payload
+        }
+      }
+    }
+  }
+  ```

--- a/cartesi-rollups/rollups-apis/graphql/queries/notice.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/notice.mdx
@@ -36,37 +36,7 @@ Informational statement that can be validated in the base layer blockchain.
 
 ## Example usage
 
-1. Get a notice based on its `inputIndex`:
-
-  ```graphql
-  query noticesByInput($inputIndex: Int!) {
-    input(index: $inputIndex) {
-      notices {
-        edges {
-          node {
-            index
-            input {
-              index
-            }
-            payload
-          }
-        }
-      }
-    }
-  }
-  ```
-
-  ```graphql
-  {
-    "inputIndex": 1
-  }
-
-  ```
-
-  In this example, the query is set to retrieve the notice at `inputIndex` `1`.
-
-
-2. Get detailed information including proof based on `noticeIndex` and `inputIndex`:
+1. Retrieve a detailed notice, including proof, using both the `noticeIndex` and `inputIndex`:
 
   ```graphql
   query notice($noticeIndex: Int!, $inputIndex: Int!) {

--- a/cartesi-rollups/rollups-apis/graphql/queries/notice.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/notice.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get notice based on its index
+Get notice based on its index:
 
 ```graphql
 notice(
@@ -15,7 +15,7 @@ notice(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `noticeIndex` ([`Int!`](../../scalars/int))
 
@@ -27,8 +27,77 @@ notice(
 
 
 
-### Type
+## Type
 
 #### [`Notice`](../../objects/notice)
 
-Informational statement that can be validated in the base layer blockchain
+Informational statement that can be validated in the base layer blockchain.
+
+
+## Example usage
+
+1. Get a notice based on its `inputIndex`:
+
+  ```graphql
+  query noticesByInput($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      notices {
+        edges {
+          node {
+            index
+            input {
+              index
+            }
+            payload
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  ```graphql
+  {
+    "inputIndex": 1
+  }
+
+  ```
+
+  In this example, the query is set to retrieve the notice at `inputIndex` `1`.
+
+
+2. Get detailed information including proof based on `noticeIndex` and `inputIndex`:
+
+  ```graphql
+  query notice($noticeIndex: Int!, $inputIndex: Int!) {
+    notice(noticeIndex: $noticeIndex, inputIndex: $inputIndex) {
+      index
+      input {
+        index
+      }
+      payload
+      proof {
+        validity {
+          inputIndexWithinEpoch
+          outputIndexWithinInput
+          outputHashesRootHash
+          vouchersEpochRootHash
+          noticesEpochRootHash
+          machineStateHash
+          outputHashInOutputHashesSiblings
+          outputHashesInEpochSiblings
+        }
+        context
+      }
+    }
+  }
+  ```
+
+  Here, the query takes two variables: `noticeIndex` and `inputIndex`.
+
+  ```graphql
+  {
+    "noticeIndex": 123,
+    "inputIndex": 1
+  }
+  ```

--- a/cartesi-rollups/rollups-apis/graphql/queries/notices.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/notices.mdx
@@ -64,3 +64,31 @@ Pagination result
     }
   }
   ```
+
+  1. Retrieve notices based on their `inputIndex`:
+
+  ```graphql
+  query noticesByInput($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      notices {
+        edges {
+          node {
+            index
+            input {
+              index
+            }
+            payload
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  ```graphql
+  {
+    "inputIndex": 1
+  }
+  ```
+
+  In this example, the query is set to retrieve all notices at `inputIndex` `1`.

--- a/cartesi-rollups/rollups-apis/graphql/queries/notices.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/notices.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get notices with support for pagination
+Get notices with support for pagination:
 
 ```graphql
 notices(
@@ -17,30 +17,50 @@ notices(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `first` ([`Int`](../../scalars/int))
-Get at most the first `n` entries (forward pagination)
+Get at most the first `n` entries(forward pagination).
 
 
 
 #### `last` ([`Int`](../../scalars/int))
-Get at most the last `n` entries (backward pagination)
+Get at most the last `n` entries(backward pagination).
 
 
 
 #### `after` ([`String`](../../scalars/string))
-Get entries that come after the provided cursor (forward pagination)
+Get entries that come after the provided cursor(forward pagination).
 
 
 
 #### `before` ([`String`](../../scalars/string))
-Get entries that come before the provided cursor (backward pagination)
+Get entries that come before the provided cursor(backward pagination).
 
 
 
-### Type
+## Type
 
 #### [`NoticeConnection`](../../objects/notice-connection)
 
 Pagination result
+
+## Example usage
+
+1. Query all notices:
+
+  ```graphql
+  query notices {
+    notices {
+      edges {
+        node {
+          index
+          input {
+            index
+          }
+          payload
+        }
+      }
+    }
+  }
+  ```

--- a/cartesi-rollups/rollups-apis/graphql/queries/report.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/report.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get report based on its index
+Get report based on its index:
 
 ```graphql
 report(
@@ -15,7 +15,7 @@ report(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `reportIndex` ([`Int!`](../../scalars/int))
 
@@ -27,8 +27,63 @@ report(
 
 
 
-### Type
+## Type
 
 #### [`Report`](../../objects/report)
 
-Application log or diagnostic information
+Application log or diagnostic information.
+
+
+## Example usage
+
+1. Get a report based on its `inputIndex`:
+
+  ```graphql
+  query reportsByInput($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      reports {
+        edges {
+          node {
+            index
+            input {
+              index
+            }
+            payload
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  ```graphql
+    {
+      "inputIndex": 2
+    }
+    ```
+
+    In this example, the query is set to retrieve the report at `inpuIndex` `2`.
+
+
+2. Fetch information about a report with its `reportIndex` and `inputIndex`:
+
+  ```graphql
+  query report($reportIndex: Int!, $inputIndex: Int!) {
+    report(reportIndex: $reportIndex, inputIndex: $inputIndex) {
+      index
+      input {
+        index
+      }
+      payload
+    }
+  }
+  ```
+
+  ```graphql
+  {
+    "reportIndex":1,
+    "inputIndex": 2
+  }
+  ```
+
+  In this example, the query is set to retrieve the report at `reportIndex` `1` and  `inputIndex` `2`.

--- a/cartesi-rollups/rollups-apis/graphql/queries/report.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/report.mdx
@@ -36,36 +36,8 @@ Application log or diagnostic information.
 
 ## Example usage
 
-1. Get a report based on its `inputIndex`:
 
-  ```graphql
-  query reportsByInput($inputIndex: Int!) {
-    input(index: $inputIndex) {
-      reports {
-        edges {
-          node {
-            index
-            input {
-              index
-            }
-            payload
-          }
-        }
-      }
-    }
-  }
-  ```
-
-  ```graphql
-    {
-      "inputIndex": 2
-    }
-    ```
-
-    In this example, the query is set to retrieve the report at `inpuIndex` `2`.
-
-
-2. Fetch information about a report with its `reportIndex` and `inputIndex`:
+1. Retrieve a report with its `reportIndex` and `inputIndex`:
 
   ```graphql
   query report($reportIndex: Int!, $inputIndex: Int!) {

--- a/cartesi-rollups/rollups-apis/graphql/queries/reports.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/reports.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get reports with support for pagination
+Get reports with support for pagination:
 
 ```graphql
 reports(
@@ -17,30 +17,50 @@ reports(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `first` ([`Int`](../../scalars/int))
-Get at most the first `n` entries (forward pagination)
+Get at most the first `n` entries(forward pagination).
 
 
 
 #### `last` ([`Int`](../../scalars/int))
-Get at most the last `n` entries (backward pagination)
+Get at most the last `n` entries(backward pagination).
 
 
 
 #### `after` ([`String`](../../scalars/string))
-Get entries that come after the provided cursor (forward pagination)
+Get entries that come after the provided cursor(forward pagination).
 
 
 
 #### `before` ([`String`](../../scalars/string))
-Get entries that come before the provided cursor (backward pagination)
+Get entries that come before the provided cursor(backward pagination).
 
 
 
-### Type
+## Type
 
 #### [`ReportConnection`](../../objects/report-connection)
 
 Pagination result
+
+## Example usage
+
+1. Query all reports:
+
+  ```graphql
+  query reports {
+    reports {
+      edges {
+        node {
+          index
+          input {
+            index
+          }
+          payload
+        }
+      }
+    }
+  }
+  ```

--- a/cartesi-rollups/rollups-apis/graphql/queries/reports.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/reports.mdx
@@ -64,3 +64,31 @@ Pagination result
     }
   }
   ```
+
+  1. Retrieve reports based on their `inputIndex`:
+
+  ```graphql
+  query reportsByInput($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      reports {
+        edges {
+          node {
+            index
+            input {
+              index
+            }
+            payload
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  ```graphql
+    {
+      "inputIndex": 2
+    }
+    ```
+
+    In this example, the query is set to retrieve all reports at `inpuIndex` `2`.

--- a/cartesi-rollups/rollups-apis/graphql/queries/voucher.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/voucher.mdx
@@ -36,37 +36,7 @@ Representation of a transaction that can be carried out on the base layer blockc
 ## Example usage
 
 
-1. Get a voucher based on its `inputIndex`:
-
-  ```graphql
-  query vouchersByInput($inputIndex: Int!) {
-    input(index: $inputIndex) {
-      vouchers {
-        edges {
-          node {
-            index
-            input {
-              index
-            }
-            destination
-            payload
-          }
-        }
-      }
-    }
-  }
-  ```
-
-  ```graphql
-  {
-    "inputIndex": 1
-  }
-
-  ```
-
-  In this example, the query is set to retrieve the voucher created at `inputIndex` `1`
-
-1. Get detailed information including proof based on `voucherIndex` and `inputIndex`:
+1.  Retrieve a detailed voucher, including proof, using both the `voucherIndex` and `inputIndex`:
 
   ```graphql
   query voucher($voucherIndex: Int!, $inputIndex: Int!) {

--- a/cartesi-rollups/rollups-apis/graphql/queries/voucher.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/voucher.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get voucher based on its index
+Get voucher based on its index:
 
 ```graphql
 voucher(
@@ -15,7 +15,7 @@ voucher(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `voucherIndex` ([`Int!`](../../scalars/int))
 
@@ -27,8 +27,78 @@ voucher(
 
 
 
-### Type
+## Type
 
 #### [`Voucher`](../../objects/voucher)
 
-Representation of a transaction that can be carried out on the base layer blockchain, such as a transfer of assets
+Representation of a transaction that can be carried out on the base layer blockchain, such as a transfer of assets.
+
+## Example usage
+
+
+1. Get a voucher based on its `inputIndex`:
+
+  ```graphql
+  query vouchersByInput($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      vouchers {
+        edges {
+          node {
+            index
+            input {
+              index
+            }
+            destination
+            payload
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  ```graphql
+  {
+    "inputIndex": 1
+  }
+
+  ```
+
+  In this example, the query is set to retrieve the voucher created at `inputIndex` `1`
+
+1. Get detailed information including proof based on `voucherIndex` and `inputIndex`:
+
+  ```graphql
+  query voucher($voucherIndex: Int!, $inputIndex: Int!) {
+    voucher(voucherIndex: $voucherIndex, inputIndex: $inputIndex) {
+      index
+      input {
+        index
+      }
+      destination
+      payload
+      proof {
+        validity {
+          inputIndexWithinEpoch
+          outputIndexWithinInput
+          outputHashesRootHash
+          vouchersEpochRootHash
+          noticesEpochRootHash
+          machineStateHash
+          outputHashInOutputHashesSiblings
+          outputHashesInEpochSiblings
+        }
+        context
+      }
+    }
+  }
+  ```
+
+  Here, the query takes two variables: `voucherIndex` and `inputIndex`.
+
+  ```graphql
+  {
+    "voucherIndex": 1,
+    "inputIndex": 5
+  }
+  ```

--- a/cartesi-rollups/rollups-apis/graphql/queries/vouchers.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/vouchers.mdx
@@ -5,7 +5,7 @@ hide_table_of_contents: false
 ---
 
 
-Get vouchers with support for pagination
+Get vouchers with support for pagination:
 
 ```graphql
 vouchers(
@@ -17,30 +17,52 @@ vouchers(
 ```
 
 
-### Arguments
+## Arguments
 
 #### `first` ([`Int`](../../scalars/int))
-Get at most the first `n` entries (forward pagination)
+Get at most the first `n` entries(forward pagination).
 
 
 
 #### `last` ([`Int`](../../scalars/int))
-Get at most the last `n` entries (backward pagination)
+Get at most the last `n` entries(backward pagination).
 
 
 
 #### `after` ([`String`](../../scalars/string))
-Get entries that come after the provided cursor (forward pagination)
+Get entries that come after the provided cursor(forward pagination).
 
 
 
 #### `before` ([`String`](../../scalars/string))
-Get entries that come before the provided cursor (backward pagination)
+Get entries that come before the provided cursor(backward pagination).
 
 
 
-### Type
+## Type
 
 #### [`VoucherConnection`](../../objects/voucher-connection)
 
-Pagination result
+Pagination result.
+
+
+## Example usage
+
+1. Query all vouchers:
+
+  ```graphql
+  query vouchers {
+    vouchers {
+      edges {
+        node {
+          index
+          input {
+            index
+          }
+          destination
+          payload
+        }
+      }
+    }
+  }
+  ```

--- a/cartesi-rollups/rollups-apis/graphql/queries/vouchers.mdx
+++ b/cartesi-rollups/rollups-apis/graphql/queries/vouchers.mdx
@@ -66,3 +66,33 @@ Pagination result.
     }
   }
   ```
+
+  1. Retrieve vouchers based on their `inputIndex`:
+
+  ```graphql
+  query vouchersByInput($inputIndex: Int!) {
+    input(index: $inputIndex) {
+      vouchers {
+        edges {
+          node {
+            index
+            input {
+              index
+            }
+            destination
+            payload
+          }
+        }
+      }
+    }
+  }
+  ```
+
+  ```graphql
+  {
+    "inputIndex": 1
+  }
+
+  ```
+
+  In this example, the query is set to retrieve all vouchers at `inputIndex` `1`

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -374,6 +374,10 @@ const config = {
             from: "/cartesi-rollups/",
           },
           {
+            to:"/cartesi-rollups/1.3/",
+            from:"/cartesi-rollups/overview"
+          },
+          {
             to: "/cartesi-machine/",
             from: ["/machine/", "/machine/intro/"],
           },
@@ -420,7 +424,7 @@ const config = {
             // only top level URLs needed. All sub levels will be matched automatically. i.e. if /cartesi-rollups/api/ added, the plugin will automatically capture /cartesi-rollups/api/json-rpc/relays/DAppAddressRelay/ etc.
             return [
               existingPath.replace(
-                "/cartesi-rollups/1.0/overview",
+                "/cartesi-rollups/1.3/",
                 "/cartesi-rollups/overview"
               ),
               existingPath.replace(


### PR DESCRIPTION
## Activities
- GraphQL API references now have example usage code for all inputs and the output types
- Fixed one minor issue with redirects

## Preview link
- https://docs-azure-two.vercel.app/cartesi-rollups/1.3/