### PR TITLE
NoNodo Installation

### DIFF
--- a/cartesi-rollups/development/running-the-application.md
+++ b/cartesi-rollups/development/running-the-application.md
@@ -83,24 +83,12 @@ NoNodo is a development tool for Cartesi Rollups designed to work with applicati
 
 Set up Anvil on your system. Refer to [the instructions in the Foundry book for Anvil installation](https://book.getfoundry.sh/anvil/) details.
 
-### Install from source
+### Install NoNodo
 
-Install Go by following [the instructions on the official Go website](https://go.dev/doc/install).
-
-Run the following command to install NoNodo:
+After setting up Anvil, install NoNodo by running:
 
 ```shell
-go install github.com/gligneul/nonodo@latest
-```
-
-This command will install NoNodo into the bin directory inside the directory specified by the `GOPATH` environment variable.
-
-Set `GOPATH` to use the NoNodo command directly.
-
-To use the NoNodo command directly, add it to the PATH variable by running:
-
-```shell
-export PATH="$HOME/go/bin:$PATH"
+npm i -g nonodo
 ```
 
 ### Usage

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -215,7 +215,7 @@ const config = {
       announcementBar: {
         id: "mainnet",
         content:
-          'Cartesi Rollups is Mainnet Ready! Over 300K in CTSI is up for grabs... if you can <a href="https://honeypot.cartesi.io/" target="_blank" rel="noopener noreferrer">hack Cartesi Rollups</a>.',
+          'Cartesi Rollups is Mainnet Ready! Over 400K in CTSI is up for grabs... if you can <a href="https://honeypot.cartesi.io/" target="_blank" rel="noopener noreferrer">hack Cartesi Rollups</a>.',
 
         backgroundColor: "rgba(0, 0, 0, 0.7)",
         textColor: "#FFFFFF",


### PR DESCRIPTION
## Brief
- Update Nonodo installation

## Activities
- Added the new update, which is the installation of NoNodo using `npm i -g nonodo` 
- Updated honeypot banner to reflect new figure, 400k

## Evidence
Preview link -> https://docs-azure-two.vercel.app/cartesi-rollups/1.3/