### PR TITLE
Fix search functionality

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -69,17 +69,17 @@ const config = {
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
       typesense: {
-        typesenseCollectionName: "cartesi_1712788548",
+        typesenseCollectionName: "cartesi_1716805080",
 
         typesenseServerConfig: {
           nodes: [
             {
-              host: "ofpew9nhydv5264qp-1.a1.typesense.net",
+              host: "chlxtu308rv7ijsfp-1.a1.typesense.net",
               port: 443,
               protocol: "https",
             },
           ],
-          apiKey: "OqZU4j8aAYx08wExdilTddIDGDh4QJov",
+          apiKey: "LfQmZC376xclgoL1ftRvR5Ap1XlVVlyz",
         },
 
         // Optional: Typesense search parameters: https://typesense.org/docs/0.24.0/api/search.html#search-parameters


### PR DESCRIPTION

## Brief
![typesense](https://github.com/cartesi/docs/assets/65580797/abe6b220-df1e-4a94-b88b-9a268896f3ca)
- Search functionality broke due to a terminated cluster

## Activities
- Scraped the docs to a new cluster 
- Updated the collection name and API config

## Preview
<img width="1011" alt="Screenshot 2024-05-27 at 10 36 27 AM" src="https://github.com/cartesi/docs/assets/65580797/ae14101b-56fa-4f2e-8c19-ad89791b9487">

https://docs-azure-two.vercel.app/cartesi-rollups/1.3/