### PR TITLE
Update doc to installation instructions for Docker RISC-V support

### DIFF
--- a/cartesi-rollups/development/installation.md
+++ b/cartesi-rollups/development/installation.md
@@ -35,31 +35,11 @@ Docker Desktop is a must-have requirement that comes pre-configured with two nec
 
 [Install the latest version of Docker Desktop](https://www.docker.com/products/docker-desktop/) for your operating system.
 
-:::troubleshoot troubleshooting common errors
+To install Docker RISC-V support without using Docker Desktop, run the following command:
 
-#### Error: Invalid image Architecture
 ```shell
-Error: Invalid image Architecture: Expected riscv64
+docker run --privileged --rm tonistiigi/binfmt:riscv
 ```
-
-#### Solution:
-
-
-1. Check if your Docker supports the RISCV platform by running:
-
-  ```shell
-  docker buildx ls
-  ```
-
-
-2. If you do not see `linux/riscv64` in the platforms list, install `QEMU` by running:
-
-  ```shell
-  apt install qemu-user-static
-  ```
-
-:::
-
 
 ## Node and NPM
 

--- a/cartesi-rollups/quickstart.md
+++ b/cartesi-rollups/quickstart.md
@@ -24,6 +24,12 @@ If you use Windows, you must have [WSL2 installed and configured](https://learn.
 
 1. [Install Docker Desktop for your operating system](https://www.docker.com/products/docker-desktop/).
 
+    To install Docker RISC-V support without using Docker Desktop, run the following command:
+    
+   ```shell
+    docker run --privileged --rm tonistiigi/binfmt:riscv
+   ```
+
 1. [Download and install the latest version of Node.js](https://nodejs.org/en/download).
 
 2. Cartesi CLI is an easy-to-use tool to build and deploy your dApps. To install it, run:
@@ -32,11 +38,6 @@ If you use Windows, you must have [WSL2 installed and configured](https://learn.
     npm i -g @cartesi/cli
    ```
 
-If not using Docker Desktop, Docker RISC-V support can be installed by running the following command:
-
-   ```shell
-    docker run --privileged --rm tonistiigi/binfmt:riscv
-   ```
 
 ## Create an application
 

--- a/cartesi-rollups/quickstart.md
+++ b/cartesi-rollups/quickstart.md
@@ -32,6 +32,11 @@ If you use Windows, you must have [WSL2 installed and configured](https://learn.
     npm i -g @cartesi/cli
    ```
 
+If not using Docker Desktop, Docker RISC-V support can be installed by running the following command:
+
+   ```shell
+    docker run --privileged --rm tonistiigi/binfmt:riscv
+   ```
 
 ## Create an application
 


### PR DESCRIPTION
## The problem
In some cases, people use CLI for handle Docker images and could be a obstacle to handle RISC-V architecture because of error is no self explain.

## How to simulate

1. Download Docker.
2. Install docker buildx and docker compose.
3. Install node and npm.
4. Create a project with Javascript, for i.e.
5. Run `cartesi build`
6. After `ADD machine-emulator`, the process of install Debian package, crashes.

```shell
=> => transferring context: 238B                                                                                  0.0s
 => [stage-1 1/6] FROM docker.io/cartesi/node:20.8.0-jammy-slim@sha256:47b872074fd14b8ff23452a7e2886ff91675671f00  0.0s
 => CACHED [stage-1 2/6] ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v0.14.1/machine-  0.0s
 => ERROR [stage-1 3/6] RUN dpkg -i /machine-emulator-tools-v0.14.1.deb   && rm /machine-emulator-tools-v0.14.1.d  1.6s
------
 > [stage-1 3/6] RUN dpkg -i /machine-emulator-tools-v0.14.1.deb   && rm /machine-emulator-tools-v0.14.1.deb:
1.314 exec /bin/sh: exec format error
------
Dockerfile:24
--------------------
  23 |     ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
  24 | >>> RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
  25 | >>>   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
  26 |
--------------------
ERROR: failed to solve: process "/bin/sh -c dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb" did not complete successfully: exit code: 1
    Error: Command failed with exit code 1: docker buildx build --load --iidfile /tmp/tmp-40925-tQXwwcaB3YB9
``````shell
=> => transferring context: 238B                                                                                  0.0s
 => [stage-1 1/6] FROM docker.io/cartesi/node:20.8.0-jammy-slim@sha256:47b872074fd14b8ff23452a7e2886ff91675671f00  0.0s
 => CACHED [stage-1 2/6] ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v0.14.1/machine-  0.0s
 => ERROR [stage-1 3/6] RUN dpkg -i /machine-emulator-tools-v0.14.1.deb   && rm /machine-emulator-tools-v0.14.1.d  1.6s
------
 > [stage-1 3/6] RUN dpkg -i /machine-emulator-tools-v0.14.1.deb   && rm /machine-emulator-tools-v0.14.1.deb:
1.314 exec /bin/sh: exec format error
------
Dockerfile:24
--------------------
  23 |     ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
  24 | >>> RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
  25 | >>>   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
  26 |
--------------------
ERROR: failed to solve: process "/bin/sh -c dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb   && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb" did not complete successfully: exit code: 1
    Error: Command failed with exit code 1: docker buildx build --load --iidfile /tmp/tmp-40925-tQXwwcaB3YB9
```

## Workaround
Add some info about support of RISC-V based in documentation from Sunodo <https://docs.sunodo.io/guide/introduction/installing#system-requirements>. See changes in this PR.

A alternative could be handle yourself with `docker buildx` like:

1. Create a emulator:

```shell
docker buildx create --name mybuilder --use --bootstrap --platform linux/amd64,linux/amd64/v2,linux/amd64/v3,linux/386,linux/riscv64
```

2. Check emulator:

```shell
docker buildx ls
```

3. Remove inactive emulators:

```shell
docker buildx rm --all-inactive
```