### PR TITLE
Update Honeypot Banner + Rollmelette tooltip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "release/*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build Docusaurus site
+        run: yarn build

--- a/cartesi-rollups/deployment/self-hosted.md
+++ b/cartesi-rollups/deployment/self-hosted.md
@@ -151,7 +151,7 @@ If deploying to Fly.io from macOS with Apple Silicon, create a Docker image for 
    ```shell
    fly secrets set -a <app-name> CARTESI_BLOCKCHAIN_HTTP_ENDPOINT=<web3-provider-http-endpoint>
    fly secrets set -a <app-name> CARTESI_BLOCKCHAIN_WS_ENDPOINT=<web3-provider-ws-endpoint>
-   fly secrets set -a <app-name> CARTESI_AUTH_MNEMONIC=<mnemonic>
+   fly secrets set -a <app-name> CARTESI_AUTH_MNEMONIC=`<mnemonic>`
    fly secrets set -a <app-name> CARTESI_POSTGRES_ENDPOINT=<connection_string>
    ```
 

--- a/cartesi-rollups/development/creating-application.md
+++ b/cartesi-rollups/development/creating-application.md
@@ -28,3 +28,8 @@ This command creates a `new-dapp` directory with essential files for your dApp d
 Cartesi CLI has templates for the following languages – `cpp`, `cpp-low-level`, `go`, `javascript`, `lua`, `python`, `ruby`, `rust`, and `typescript`.
 
 After creating your application, you can start building your dApp by adding your logic to the `dapp.py` file.
+
+
+:::note Building with Go?
+For Go applications on Cartesi, we recommend using [Rollmelette](https://github.com/rollmelette/rollmelette). It’s a high-level Go framework and an alternative template that simplifies development and enhances input management, providing a smoother and more efficient experience.
+:::

--- a/cartesi-rollups/quickstart.md
+++ b/cartesi-rollups/quickstart.md
@@ -148,7 +148,7 @@ Several tools created and maintained by the community streamline the dApp creati
 - [Deroll](https://github.com/tuler/deroll): TypeScript framework for building on Cartesi.
 - [python-cartesi](https://github.com/prototyp3-dev/python-cartesi): Python framework for building on Cartesi.
 - [cartesi-ts-sqlite](https://github.com/doiim/cartesi-ts-sqlite): A TypeScript + SQLite template.
-- [Rollmellete](https://github.com/gligneul/rollmelette): Go framework for building on Cartesi.
+- [Rollmelette](https://github.com/gligneul/rollmelette): Go framework for building on Cartesi.
 - [Cartesify](https://github.com/Calindra/cartesify): A web3 client to interact with the Cartesi machine.
 - [cartesi-router](https://github.com/jjhbk/cartesi-router): TypeScript-based Router Implementation for Cartesi dApps.
 - [cartesi-wallet](https://github.com/jjhbk/cartesi-wallet): TypeScript-based Wallet Implementation for Cartesi dApps.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -215,7 +215,7 @@ const config = {
       announcementBar: {
         id: "mainnet",
         content:
-          'Cartesi Rollups is Mainnet Ready! Over 600K in CTSI is up for grabs... if you can <a href="https://honeypot.cartesi.io/" target="_blank" rel="noopener noreferrer">hack Cartesi Rollups</a>.',
+          'Cartesi Rollups is Mainnet Ready! Over 700K in CTSI is up for grabs... if you can <a href="https://honeypot.cartesi.io/" target="_blank" rel="noopener noreferrer">hack Cartesi Rollups</a>.',
 
         backgroundColor: "rgba(0, 0, 0, 0.7)",
         textColor: "#FFFFFF",


### PR DESCRIPTION
## Brief
- Amplify Rollmelette in docs
- Update Honeypot banner
- GitHub actions

## Activities
- Honeypot now has 700k in CTSI. Updating the banner to reflect this
- Giving Rollmelette the spotlight it deserves as put [here](https://discord.com/channels/600597137524391947/1001118234327666728/1253356447811764408)
- GitHub actions to ensure a successful build before merging
- Minor backtick addition to the deployment guide

## Evidence
https://docs-azure-two.vercel.app/cartesi-rollups/1.3/development/creating-application/
