### PR TITLE
Add Tooltip Warning for Inspect Requests

### DIFF
--- a/cartesi-rollups/development/send-requests.md
+++ b/cartesi-rollups/development/send-requests.md
@@ -210,6 +210,10 @@ Here is a [React.js + Typescript template](https://github.com/prototyp3-dev/fron
 
 Inspect requests are directly made to the rollup server, and the Cartesi Machine is activated without modifying its state.
 
+:::caution Inspect requests
+Inspect requests are best suited for non-production use, such as debugging and testing. They may not function reliably in production environments, potentially leading to errors or disruptions.
+:::
+
 ![img](../../static/img/v1.3/inspect.jpg)
 
 You can make a simple inspect call from your frontend client to retrieve reports.

--- a/cartesi-rollups/rollups-apis/backend/introduction.md
+++ b/cartesi-rollups/rollups-apis/backend/introduction.md
@@ -11,6 +11,10 @@ The backend of a Cartesi dApp retrieves a new request as follows:
 
   - **Inspect** — This function submits a query about the application's current state. When running inside a Cartesi Machine, this operation is guaranteed to leave the state unchanged since the machine is reverted to its exact previous condition after processing. For Inspect requests, the input data has only a payload.
 
+  :::caution Inspect requests
+  Inspect requests are best suited for non-production use, such as debugging and testing. They may not function reliably in production environments, potentially leading to errors or disruptions.
+  :::
+
 ## Advance and Inspect
 
 Here is a simple boilerplate application that handles Advance and Inspect requests:


### PR DESCRIPTION
## Description:
Added a tooltip to the Inspect Requests section to inform users that inspect requests are primarily for debugging and may not be reliable in production environments. This ensures users know potential issues when using inspect requests in live settings.

## Changes:
•	Added a tooltip next to the Inspect Requests header with a cautionary message.

## Preview
https://docs-azure-two.vercel.app/cartesi-rollups/1.3/rollups-apis/backend/introduction/
https://docs-azure-two.vercel.app/cartesi-rollups/1.3/development/send-requests/#make-inspect-calls