### PR TITLE
Update Documentation for Inspect Requests and NoNodo

### DIFF
--- a/cartesi-rollups/quickstart.md
+++ b/cartesi-rollups/quickstart.md
@@ -146,6 +146,7 @@ Deployment with a third-party service provider is under development and will be 
 Several tools created and maintained by the community streamline the dApp creation process on Cartesi Rollups.
 
 - [Deroll](https://github.com/tuler/deroll): TypeScript framework for building on Cartesi.
+- [NoNodo](https://github.com/Calindra/nonodo/tree/main): NoNodo is a lightweight development tool that runs the backend application without requiring Docker or a node.
 - [python-cartesi](https://github.com/prototyp3-dev/python-cartesi): Python framework for building on Cartesi.
 - [cartesi-ts-sqlite](https://github.com/doiim/cartesi-ts-sqlite): A TypeScript + SQLite template.
 - [Rollmelette](https://github.com/gligneul/rollmelette): Go framework for building on Cartesi.

--- a/cartesi-rollups/rollups-apis/backend/introduction.md
+++ b/cartesi-rollups/rollups-apis/backend/introduction.md
@@ -148,4 +148,5 @@ curl http://localhost:8080/inspect/mypath
 
 Once the call's response is received, the payload is extracted from the response data, allowing the backend code to examine it and produce outputs as **reports**.
 
-The direct output types for **Advance** and **Inspect** are [vouchers](./vouchers.md), [notices](./notices.md), and [reports](./reports.md).
+
+The direct output types for **Advance** requests are [vouchers](./vouchers.md), [notices](./notices.md), and [reports](./reports.md), while **Inspect** requests generate only [reports](./reports.md).


### PR DESCRIPTION
## Description:
- Clarified the output types for Advance and Inspect requests, noting that Inspect requests generate only reports.
- Added NoNodo to community tools

## Changes:
- Revised the sentence about Advance and Inspect request outputs.
- Added NoNodo description to community tools section on 

## Preview
https://docs-azure-two.vercel.app/cartesi-rollups/1.3/rollups-apis/backend/introduction/
https://docs-azure-two.vercel.app/cartesi-rollups/1.3/quickstart/#community-tools