### PR TITLE
Update rollups-contracts URLs to v1.4.0

### DIFF
--- a/cartesi-rollups/deployment/introduction.md
+++ b/cartesi-rollups/deployment/introduction.md
@@ -2,7 +2,7 @@
 id: introduction
 title: Introduction
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/tree/main/deployments
+  - url: https://github.com/cartesi/rollups-contracts/tree/v1.4.0/onchain/rollups/deployments
     title: Supported networks
 
 ---
@@ -39,7 +39,7 @@ Deployment with a third-party service provider is under development and will be 
 
 As stated above, the first step in deploying a new Cartesi dApp to a blockchain requires creating a smart contract on that network that uses the Cartesi Rollups smart contracts. Cartesi has already deployed the Rollups smart contracts to several networks for convenience.
 
-The table below shows the list of all [networks that are currently supported](https://github.com/cartesi/rollups-contracts/tree/main/deployments) in the latest release:
+The table below shows the list of all [networks that are currently supported](https://github.com/cartesi/rollups-contracts/tree/v1.4.0/onchain/rollups/deployments) in the latest release:
 
 | Network Name     | Chain ID |
 | ---------------- | -------- |

--- a/cartesi-rollups/rollups-apis/index.md
+++ b/cartesi-rollups/rollups-apis/index.md
@@ -6,7 +6,7 @@ resources:
     title: Off-chain implementation of the Cartesi Machine
   - url: https://github.com/cartesi/rollups-node
     title: Reference implementation of the Rollups Node
-  - url: https://github.com/cartesi/rollups-contracts
+  - url: https://github.com/cartesi/rollups-contracts/tree/v1.4.0/onchain/rollups/contracts
     title: Smart Contracts for Cartesi Rollups
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/application-factory.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/application-factory.md
@@ -2,7 +2,7 @@
 id: application-factory
 title: CartesiDAppFactory
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/dapp/CartesiDAppFactory.sol
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/dapp/CartesiDAppFactory.sol
     title: CartesiDAppFactory contract
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/application.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/application.md
@@ -2,7 +2,7 @@
 id: application
 title: CartesiDApp
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/dapp/CartesiDApp.sol
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/dapp/CartesiDApp.sol
     title: CartesiDApp contract
   - url: https://docs.openzeppelin.com/contracts/5.x/
     title: OpenZeppelin Contracts

--- a/cartesi-rollups/rollups-apis/json-rpc/input-box.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/input-box.md
@@ -2,7 +2,7 @@
 id: input-box
 title: InputBox
 resources:
-    - url: https://github.com/cartesi/rollups-contracts/tree/main/contracts/inputs
+    - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/inputs/InputBox.sol
       title: InputBox contract
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/overview.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/overview.md
@@ -2,7 +2,7 @@
 id: overview
 title: Overview
 resources:
-  - url: https://github.com/cartesi/rollups-contracts
+  - url: https://github.com/cartesi/rollups-contracts/tree/v1.4.0/onchain/rollups/contracts
     title: Smart Contracts for Cartesi Rollups
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/portals/ERC1155BatchPortal.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/portals/ERC1155BatchPortal.md
@@ -1,6 +1,6 @@
 ---
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/portals/ERC1155BatchPortal.sol
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/portals/ERC1155BatchPortal.sol
     title: ERC1155BatchPortal contract
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/portals/ERC1155SinglePortal.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/portals/ERC1155SinglePortal.md
@@ -1,6 +1,6 @@
 ---
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/portals/ERC1155SinglePortal.sol
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/portals/ERC1155SinglePortal.sol
     title: ERC1155SinglePortal contract
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/portals/ERC20Portal.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/portals/ERC20Portal.md
@@ -1,7 +1,7 @@
 ---
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/tree/main/contracts/portals
-    title: Portals contract
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/portals/ERC20Portal.sol
+    title: ERC20 Portal contract
 ---
 
 The **ERC20Portal** allows anyone to perform transfers of

--- a/cartesi-rollups/rollups-apis/json-rpc/portals/ERC721Portal.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/portals/ERC721Portal.md
@@ -1,7 +1,7 @@
 ---
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/portals/ERC721Portal.sol
-    title: ERC721Portals contract
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/portals/ERC721Portal.sol
+    title: ERC721Portal contract
 ---
 
 The **ERC721Portal** allows anyone to perform transfers of

--- a/cartesi-rollups/rollups-apis/json-rpc/portals/EtherPortal.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/portals/EtherPortal.md
@@ -1,6 +1,6 @@
 ---
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/portals/EtherPortal.sol
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/portals/EtherPortal.sol
     title: EtherPortal contract
 ---
 

--- a/cartesi-rollups/rollups-apis/json-rpc/relays/relays.md
+++ b/cartesi-rollups/rollups-apis/json-rpc/relays/relays.md
@@ -2,7 +2,7 @@
 id: relays
 title: DAppAddressRelay
 resources:
-  - url: https://github.com/cartesi/rollups-contracts/blob/v1.2.0/onchain/rollups/contracts/relays/DAppAddressRelay.sol
+  - url: https://github.com/cartesi/rollups-contracts/blob/v1.4.0/onchain/rollups/contracts/relays/DAppAddressRelay.sol
     title: DAppAddressRelay contract
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -215,7 +215,7 @@ const config = {
       announcementBar: {
         id: "mainnet",
         content:
-          'Cartesi Rollups is Mainnet Ready! Over 800K in CTSI is up for grabs... if you can <a href="https://honeypot.cartesi.io/" target="_blank" rel="noopener noreferrer">hack Cartesi Rollups</a>.',
+          'Cartesi Rollups is Mainnet Ready! Over 950K in CTSI is up for grabs... if you can <a href="https://honeypot.cartesi.io/" target="_blank" rel="noopener noreferrer">hack Cartesi Rollups</a>.',
 
         backgroundColor: "rgba(0, 0, 0, 0.7)",
         textColor: "#FFFFFF",


### PR DESCRIPTION
Updated the link to the rollups contracts contract in the documentation to point to version 1.4.0 tag