### PR TITLE
Update event parameter name in InputAdded event

### DIFF
--- a/cartesi-rollups_versioned_docs/version-1.5/rollups-apis/json-rpc/input-box.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/rollups-apis/json-rpc/input-box.md
@@ -18,7 +18,7 @@ From the perspective of this contract, inputs are encoding-agnostic byte arrays.
 ## `InputAdded()`
 
 ```solidity
-event InputAdded(address dapp, uint256 inboxInputIndex, address sender, bytes input)
+event InputAdded(address dapp, uint256 inputIndex, address sender, bytes input)
 ```
 
 Emitted when an input is added to a dApp's input box.
@@ -28,7 +28,7 @@ Emitted when an input is added to a dApp's input box.
 | Name            | Type    | Description                             |
 | --------------- | ------- | --------------------------------------- |
 | dapp            | address | The address of the dApp                 |
-| inboxInputIndex | uint256 | The index of the input in the input box |
+| inputIndex | uint256 | The index of the input in the input box |
 | sender          | address | The address that sent the input         |
 | input           | bytes   | The contents of the input               |
 


### PR DESCRIPTION
## Brief
- Fix wrong parameter

## Activities
- This PR fixes #217 

## Evidence
https://docs-azure-two.vercel.app/cartesi-rollups/1.5/rollups-apis/json-rpc/input-box/#inputadded