### PR TITLE
Fix inspect warning and correct OutputValidityProof structure

### DIFF
--- a/cartesi-rollups_versioned_docs/version-1.0/api/json-rpc/sol-output.md
+++ b/cartesi-rollups_versioned_docs/version-1.0/api/json-rpc/sol-output.md
@@ -234,8 +234,8 @@ Data used to prove the validity of an output (notices and vouchers)
 
 ```solidity
 struct OutputValidityProof {
-  uint256 inputIndexWithinEpoch;
-  uint256 outputIndexWithinInput;
+  uint64 inputIndexWithinEpoch;
+  uint64 outputIndexWithinInput;
   bytes32 outputHashesRootHash;
   bytes32 vouchersEpochRootHash;
   bytes32 noticesEpochRootHash;
@@ -249,8 +249,8 @@ struct OutputValidityProof {
 
 | Name                             | Type      | Description                                                       |
 | -------------------------------- | --------- | ----------------------------------------------------------------- |
-| inputIndexWithinEpoch            | uint256   | Which input, inside the epoch, the output belongs to              |
-| outputIndexWithinInput           | uint256   | Index of output emitted by the input                              |
+| inputIndexWithinEpoch            | uint64   | Which input, inside the epoch, the output belongs to              |
+| outputIndexWithinInput           | uint64   | Index of output emitted by the input                              |
 | outputHashesRootHash             | bytes32   | Merkle root of hashes of outputs emitted by the input             |
 | vouchersEpochRootHash            | bytes32   | Merkle root of all epoch's voucher metadata hashes                |
 | noticesEpochRootHash             | bytes32   | Merkle root of all epoch's notice metadata hashes                 |

--- a/cartesi-rollups_versioned_docs/version-1.3/development/send-requests.md
+++ b/cartesi-rollups_versioned_docs/version-1.3/development/send-requests.md
@@ -207,7 +207,7 @@ Here is a [React.js + Typescript template](https://github.com/prototyp3-dev/fron
 Inspect requests are directly made to the rollup server, and the Cartesi Machine is activated without modifying its state.
 
 :::caution Inspect requests
-Inspect requests are best suited for non-production use, such as debugging and testing. They may not function reliably in production environments, potentially leading to errors or disruptions.
+Inspect requests should be used cautiously in production environments with heavy traffic or limited resources. Performing thorough stress testing in a staging environment is recommended to assess the impact of Inspect calls on node performance.
 :::
 
 ![img](../../../static/img/v1.3/inspect.jpg)

--- a/cartesi-rollups_versioned_docs/version-1.3/rollups-apis/json-rpc/application.md
+++ b/cartesi-rollups_versioned_docs/version-1.3/rollups-apis/json-rpc/application.md
@@ -226,8 +226,8 @@ Data used to prove the validity of an output (notices and vouchers)
 
 ```solidity
 struct OutputValidityProof {
-  uint256 inputIndexWithinEpoch;
-  uint256 outputIndexWithinInput;
+  uint64 inputIndexWithinEpoch;
+  uint64 outputIndexWithinInput;
   bytes32 outputHashesRootHash;
   bytes32 vouchersEpochRootHash;
   bytes32 noticesEpochRootHash;
@@ -241,8 +241,8 @@ struct OutputValidityProof {
 
 | Name                             | Type      | Description                                                       |
 | -------------------------------- | --------- | ----------------------------------------------------------------- |
-| inputIndexWithinEpoch            | uint256   | Which input, inside the epoch, the output belongs to              |
-| outputIndexWithinInput           | uint256   | Index of output emitted by the input                              |
+| inputIndexWithinEpoch            | uint64   | Which input, inside the epoch, the output belongs to              |
+| outputIndexWithinInput           | uint64   | Index of output emitted by the input                              |
 | outputHashesRootHash             | bytes32   | Merkle root of hashes of outputs emitted by the input             |
 | vouchersEpochRootHash            | bytes32   | Merkle root of all epoch's voucher metadata hashes                |
 | noticesEpochRootHash             | bytes32   | Merkle root of all epoch's notice metadata hashes                 |

--- a/cartesi-rollups_versioned_docs/version-1.5/development/send-requests.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/development/send-requests.md
@@ -207,7 +207,7 @@ Follow [the React.js tutorial to build a frontend for your application](../tutor
 Inspect requests are directly made to the rollup server, and the Cartesi Machine is activated without modifying its state.
 
 :::caution Inspect requests
-Inspect requests are best suited for non-production use, such as debugging and testing. They may not function reliably in production environments, potentially leading to errors or disruptions.
+Inspect requests should be used cautiously in production environments with heavy traffic or limited resources. Performing thorough stress testing in a staging environment is recommended to assess the impact of Inspect calls on node performance.
 :::
 
 ![img](../../../static/img/v1.3/inspect.jpg)

--- a/cartesi-rollups_versioned_docs/version-1.5/rollups-apis/json-rpc/application.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/rollups-apis/json-rpc/application.md
@@ -226,8 +226,8 @@ Data used to prove the validity of an output (notices and vouchers)
 
 ```solidity
 struct OutputValidityProof {
-  uint256 inputIndexWithinEpoch;
-  uint256 outputIndexWithinInput;
+  uint64 inputIndexWithinEpoch;
+  uint64 outputIndexWithinInput;
   bytes32 outputHashesRootHash;
   bytes32 vouchersEpochRootHash;
   bytes32 noticesEpochRootHash;
@@ -241,8 +241,8 @@ struct OutputValidityProof {
 
 | Name                             | Type      | Description                                                       |
 | -------------------------------- | --------- | ----------------------------------------------------------------- |
-| inputIndexWithinEpoch            | uint256   | Which input, inside the epoch, the output belongs to              |
-| outputIndexWithinInput           | uint256   | Index of output emitted by the input                              |
+| inputIndexWithinEpoch            | uint64   | Which input, inside the epoch, the output belongs to              |
+| outputIndexWithinInput           | uint64   | Index of output emitted by the input                              |
 | outputHashesRootHash             | bytes32   | Merkle root of hashes of outputs emitted by the input             |
 | vouchersEpochRootHash            | bytes32   | Merkle root of all epoch's voucher metadata hashes                |
 | noticesEpochRootHash             | bytes32   | Merkle root of all epoch's notice metadata hashes                 |


### PR DESCRIPTION
### Changed
- reframed Inspect warning to accommodate cautious production usage
- corrected variable types of `inputIndexWithinEpoch` and `outputIndexWithinInput` inside `OutputValidityProof` structure
