### PR TITLE
fix(development): :construction: Fixing the reference to the Ether portal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "conventionalCommits.scopes": [
+    "development"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-  "conventionalCommits.scopes": [
-    "development"
-  ]
-}

--- a/cartesi-rollups_versioned_docs/version-1.5/development/asset-handling.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/development/asset-handling.md
@@ -12,7 +12,7 @@ As with any execution layer solution, a Cartesi dApp that wants to manipulate as
 
 Currently, Cartesi Rollups support the following types of assets:
 
-- [Ether (ETH)](../rollups-apis/json-rpc/portals/)
+- [Ether (ETH)](../rollups-apis/json-rpc/portals/EtherPortal.md)
 - [ERC-20](../rollups-apis/json-rpc/portals/ERC20Portal.md)
 - [ERC-721](../rollups-apis/json-rpc/portals/ERC721Portal.md)
 - [ERC-1155 Single](../rollups-apis/json-rpc/portals/ERC1155SinglePortal.md)


### PR DESCRIPTION
This PR introduces a fix to the reference for the Ether portal present in version 1.5 under the development section in the topic Asset Handling, as can be verified here:

https://docs.cartesi.io/cartesi-rollups/1.5/development/asset-handling/