### PR TITLE
The typos in the text is in the command Update requirements.md

### DIFF
--- a/docs/tutorials/requirements.md
+++ b/docs/tutorials/requirements.md
@@ -102,8 +102,8 @@ sudo apt-get install -y nodejs
 And then test them:
 
 ```bash
-node –-version
-npm –-version
+node --version
+npm --version
 ```
 
 ## Yarn


### PR DESCRIPTION
The typo in the text is in the command:

```bash
node –-version
```

The dash used before `version` is an **en dash** (`–`) rather than a **hyphen-minus** (`-`), which is the correct character for command-line options.

Corrected version:
```bash
node --version
```

The same issue occurs with the `npm` command:

```bash
npm –-version
```

Corrected version:
```bash
npm --version
```

Fixed.