### PR TITLE
docs(v1.5): add fly.io service startup timeout workaround

### DIFF
--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -121,7 +121,7 @@ The Cartesi rollups node v1.5 has a hard-coded 5-second startup timeout per serv
 The steps below replace the default node image with a custom Dockerfile that uses [nitro](https://github.com/leahneukirchen/nitro) and nginx as the process supervisor and HTTP proxy, which have no startup timeout. Download the Dockerfile into your project directory before proceeding:
 
 ```shell
-curl -L https://gist.github.com/jplgarcia/09bdffab9e443b7d0e85001a5806ad4a/raw -o Dockerfile.fly
+curl -L https://raw.githubusercontent.com/Mugen-Builders/cartesi-flyio-workaround/main/Dockerfile.fly -o Dockerfile.fly
 ```
 :::
 

--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -115,6 +115,16 @@ Fly.io is a platform where you can conveniently deploy applications packaged as
 If deploying to Fly.io from macOS with Apple Silicon, create a Docker image for `linux/amd64` with: `cartesi deploy build --platform linux/amd64`
 :::
 
+:::caution known issue: service startup timeout
+The Cartesi rollups node v1.5 has a hard-coded 5-second startup timeout per service. On Fly.io, services such as the `inspect-server` can take longer to initialise, causing the node to restart immediately after launch.
+
+The steps below replace the default node image with a custom Dockerfile that uses [nitro](https://github.com/leahneukirchen/nitro) and nginx as the process supervisor and HTTP proxy, which have no startup timeout. Download the Dockerfile into your project directory before proceeding:
+
+```shell
+curl -L https://gist.github.com/jplgarcia/09bdffab9e443b7d0e85001a5806ad4a/raw -o Dockerfile.fly
+```
+:::
+
 1. [Install the flyctl CLI](https://fly.io/docs/hands-on/install-flyctl/)
 
 1. [Create an account](https://fly.io/docs/hands-on/sign-up-sign-in/)
@@ -159,11 +169,11 @@ If deploying to Fly.io from macOS with Apple Silicon, create a Docker image for 
 
 1. Deploy the node:
 
-   Tag the image produced at the beginning of the process and push it to the Fly.io registry:
+   Build the image using the `Dockerfile.fly` you downloaded earlier and push it to the Fly.io registry:
 
    ```shell
    flyctl auth docker
-   docker image tag <image-id> registry.fly.io/<app-name>
+   docker build --platform linux/amd64 -f Dockerfile.fly -t registry.fly.io/<app-name> .cartesi/image/
    docker image push registry.fly.io/<app-name>
    fly deploy -a <app-name>
    ```

--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -165,7 +165,7 @@ curl -L https://raw.githubusercontent.com/Mugen-Builders/cartesi-flyio-workaroun
    fly secrets set -a <app-name> CARTESI_POSTGRES_ENDPOINT=<connection_string>
    ```
 
-   Set value of the `connection_string` as provided by step 4.
+   Set value of the `connection_string` as provided by step 5.
 
 1. Deploy the node:
 

--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -85,6 +85,10 @@ Alternatively, you can use a service like [Fly.io](https://fly.io/) to deploy yo
 
   ![img](../../../static/img/v1.3/alchemy.png)
 
+  :::tip RPC provider
+  [Infura](https://infura.io) works on the free tier for testnets. [Alchemy](https://alchemy.com) requires a paid plan to avoid rate-limit errors under node load.
+  :::
+
   :::caution important
   The web3 provider URLs and wallet mnemonic are sensitive information that can compromise your application and funds. You should keep it **secure** and **private** at all times.
   :::

--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -167,6 +167,10 @@ curl -L https://raw.githubusercontent.com/Mugen-Builders/cartesi-flyio-workaroun
 
    Set value of the `connection_string` as provided by step 5.
 
+   :::tip RPC provider
+   [Infura](https://infura.io) works on the free tier for testnets. [Alchemy](https://alchemy.com) requires a paid plan to avoid rate-limit errors under node load.
+   :::
+
 1. Deploy the node:
 
    Build the image using the `Dockerfile.fly` you downloaded earlier and push it to the Fly.io registry:

--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -171,10 +171,6 @@ curl -L https://raw.githubusercontent.com/Mugen-Builders/cartesi-flyio-workaroun
 
    Set value of the `connection_string` as provided by step 5.
 
-   :::tip RPC provider
-   [Infura](https://infura.io) works on the free tier for testnets. [Alchemy](https://alchemy.com) requires a paid plan to avoid rate-limit errors under node load.
-   :::
-
 1. Deploy the node:
 
    Build the image using the `Dockerfile.fly` you downloaded earlier and push it to the Fly.io registry:

--- a/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
+++ b/cartesi-rollups_versioned_docs/version-1.5/deployment/self-hosted.md
@@ -125,7 +125,7 @@ The Cartesi rollups node v1.5 has a hard-coded 5-second startup timeout per serv
 The steps below replace the default node image with a custom Dockerfile that uses [nitro](https://github.com/leahneukirchen/nitro) and nginx as the process supervisor and HTTP proxy, which have no startup timeout. Download the Dockerfile into your project directory before proceeding:
 
 ```shell
-curl -L https://raw.githubusercontent.com/Mugen-Builders/cartesi-flyio-workaround/main/Dockerfile.fly -o Dockerfile.fly
+curl -L https://raw.githubusercontent.com/Mugen-Builders/cartesi-flyio-workaround/8de6beb730957aee453a2b146c23a15a060baf56/Dockerfile.fly -o Dockerfile.fly
 ```
 :::
 


### PR DESCRIPTION
## Problem

The Cartesi rollups node v1.5 go-supervisor has a hard-coded 5-second startup timeout per service. On Fly.io, `inspect-server` (and occasionally `server-manager`) take longer than 5 seconds to become ready, causing the node to restart immediately after launch.

## Change

Added a **Known issue** caution block to the v1.5 **Hosting on fly.io** section that:
- Explains the 5-second timeout root cause
- Provides a custom `Dockerfile.fly` (hosted at [Mugen-Builders/cartesi-flyio-workaround](https://github.com/Mugen-Builders/cartesi-flyio-workaround)) that replaces the go-supervisor with [nitro](https://github.com/leahneukirchen/nitro) + nginx, which have no startup timeout
- Updates the **Deploy the node** step to build from `Dockerfile.fly` instead of tagging the default image

## Related

A root-cause fix (making the timeout configurable via `CARTESI_SERVICE_READY_TIMEOUT`) is proposed in [cartesi/rollups-node#750](https://github.com/cartesi/rollups-node/pull/750). Once that is merged and released, this workaround section can be replaced with a simple env-var note.
